### PR TITLE
Increase performance when selecting mods

### DIFF
--- a/xcom2-launcher/xcom2-launcher/Forms/MainForm.ModList.cs
+++ b/xcom2-launcher/xcom2-launcher/Forms/MainForm.ModList.cs
@@ -393,35 +393,30 @@ namespace XCOM2Launcher.Forms
             CreateModListContextMenu(e.Model as ModEntry).Show(e.ListView, e.Location);
         }
 
-        private Timer _updateTimer;
-
         private void ModListItemChecked(object sender, ItemCheckedEventArgs e)
         {
-            // If there is a duplicate id conflict 
-            // check all at the same time
             var modChecked = ModList.GetModelObject(e.Item.Index);
+
+            List<ModEntry> updatedMods = new List<ModEntry>();
+            
+            // If there is a duplicate id conflict check all
+            // at the same time and mark them as updated
             if (modChecked.State.HasFlag(ModState.DuplicateID))
             {
                 foreach (var mod in Mods.All.Where(@mod => mod.ID == modChecked.ID))
                 {
                     mod.isActive = modChecked.isActive;
+                    updatedMods.Add(mod);
                     UpdateMod(mod);
                 }
             }
-            // put on a slight delay
-            // so it will only update once
-            if (_updateTimer != null && _updateTimer.Enabled)
-                return;
-
-            _updateTimer = new Timer(10)
+            // Otherwise just mark the one as updated
+            else
             {
-                SynchronizingObject = this,
-                AutoReset = false
-            };
+                updatedMods.Add(modChecked);
+            }
 
-            _updateTimer.Elapsed += delegate { UpdateConflicts(); };
-
-            _updateTimer.Start();
+            UpdateConflictsForMods(updatedMods);
         }
 
         private void ModListSelectionChanged(object sender, EventArgs e)

--- a/xcom2-launcher/xcom2-launcher/Forms/MainForm.cs
+++ b/xcom2-launcher/xcom2-launcher/Forms/MainForm.cs
@@ -266,9 +266,10 @@ namespace XCOM2Launcher.Forms
 
         private void UpdateConflicts()
         {
+            // Incremented later in GetDuplicatesString() and GetOverridesString()
             NumConflicts = 0;
 
-            // Fill ClassOverride DataGrid 
+            // Clear and refill conflicts_datagrid
             conflicts_datagrid.Rows.Clear();
 
             foreach (var m in Mods.Active)
@@ -287,8 +288,57 @@ namespace XCOM2Launcher.Forms
             // Conflict log
             conflicts_textbox.Text = GetDuplicatesString() + GetOverridesString();
 
-            // Update Interface
+            // Update interface
             modlist_ListObjectListView.UpdateObjects(ModList.Objects.ToList());
+            UpdateLabels();
+        }
+
+        private void UpdateConflictsForMods(List<ModEntry> mods)
+        {
+            // Incremented later in GetDuplicatesString() and GetOverridesString()
+            NumConflicts = 0;
+
+            // Update conflicts_datagrid
+            foreach (var m in mods)
+            {
+                if (m.isActive)
+                {
+                    foreach (var classOverride in m.GetOverrides(true))
+                    {
+                        var oldClass = classOverride.OldClass;
+
+                        if (classOverride.OverrideType == ModClassOverrideType.UIScreenListener)
+                            oldClass += " (UIScreenListener)";
+
+                        conflicts_datagrid.Rows.Add(m.Name, oldClass, classOverride.NewClass);
+                    }
+                }
+                else
+                {
+                    foreach (var classOverride in m.GetOverrides(true))
+                    {
+                        foreach (var row in conflicts_datagrid.Rows.Cast<DataGridViewRow>())
+                        {
+                            var oldClass = classOverride.OldClass;
+
+                            if (classOverride.OverrideType == ModClassOverrideType.UIScreenListener)
+                                oldClass += " (UIScreenListener)";
+
+                            if ((string)row.Cells[0].Value == m.Name && (string)row.Cells[1].Value == oldClass && (string)row.Cells[2].Value == classOverride.NewClass)
+                            {
+                                conflicts_datagrid.Rows.Remove(row);
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Conflict log
+            conflicts_textbox.Text = GetDuplicatesString() + GetOverridesString();
+
+            // Update interface
+            modlist_ListObjectListView.UpdateObjects(mods);
             UpdateLabels();
         }
 


### PR DESCRIPTION
Makes selecting and deselecting both individual mods and groups of mods
take less time. This is achieved by adding or removing only the affected
mod conflicts from the conflicts screen instead of clearing the screen
and adding all the mod conflicts at once.