### PR TITLE
Fix for duplicate mod paths being created.

### DIFF
--- a/xcom2-launcher/xcom2-launcher/Program.cs
+++ b/xcom2-launcher/xcom2-launcher/Program.cs
@@ -156,8 +156,17 @@ namespace XCOM2Launcher
                 settings.ModPaths.Remove(modPath);
 
             foreach (var modPath in XCOM2.DetectModDirs())
+            {
                 if (!settings.ModPaths.Contains(modPath))
-                    settings.ModPaths.Add(modPath);
+                {
+                    if (!settings.ModPaths.Contains(modPath + "\\"))
+                    {
+                        settings.ModPaths.Add(modPath);
+                    }
+                }
+
+            }
+
 
             if (settings.ModPaths.Count == 0)
                 MessageBox.Show(@"Could not find XCOM 2 mod directories. Please fill them in manually in the settings.");

--- a/xcom2-launcher/xcom2-launcher/packages.config
+++ b/xcom2-launcher/xcom2-launcher/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="FCTB" version="2.16.21.0" targetFramework="net46" />
   <package id="GitVersionTask" version="3.6.5" targetFramework="net46" developmentDependency="true" />
-  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net46" />
   <package id="ObjectListView.Official" version="2.9.1" targetFramework="net46" />
 </packages>

--- a/xcom2-launcher/xcom2-launcher/xcom2-launcher.csproj
+++ b/xcom2-launcher/xcom2-launcher/xcom2-launcher.csproj
@@ -106,9 +106,8 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualBasic" />
-    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="ObjectListView">
       <HintPath>..\packages\ObjectListView.Official.2.9.1\lib\net20\ObjectListView.dll</HintPath>


### PR DESCRIPTION
For issue #20 , as the launcher didn't fully check mod paths: it *made* a correct path for systems that needed the `\\`, but didn't check if the paths that already existed had the `\\`.

