### PR TITLE
Fixes mod description text formatting issue

### DIFF
--- a/xcom2-launcher/xcom2-launcher/Forms/MainForm.cs
+++ b/xcom2-launcher/xcom2-launcher/Forms/MainForm.cs
@@ -504,6 +504,7 @@ namespace XCOM2Launcher.Forms
             modinfo_info_DateCreatedTextBox.Text = m.DateCreated?.ToString() ?? "";
             modinfo_info_InstalledTextBox.Text = m.DateAdded?.ToString() ?? "";
             modinfo_info_DescriptionRichTextBox.Font = DefaultFont;
+            modinfo_info_DescriptionRichTextBox.Clear();
             modinfo_info_DescriptionRichTextBox.Rtf = m.GetDescription(true);
             btnDescSave.Enabled = false;
             modinfo_readme_RichTextBox.Text = m.GetReadMe();


### PR DESCRIPTION
Calling Clear() on the mod description RichTextBox before assigning Rtf seems to fix the issue, where everything starts to appear in bold. Resolves #81.

I can't explain why this works or what the actual cause is, that messes the RichTextBox up. Maybe the RTB control is buggy, maybe some really strange/wrong/invalid rich text formatting causes this. Potentially both. I have no clue what is going on with respect to the BBCode parsing, so I haven't looked into that.

While testing, I noticed, that the problem only happens after selecting specific mods. One example is [[WOTC] Additional Icons](https://steamcommunity.com/sharedfiles/filedetails/?id=1127409511). The description of the mod is displayed correctly at first, but starting with the next selection, everything appears in bold.

Please confirm that this works and I would say we consider this closed.
