### PR TITLE
Improved mod path processing

### DIFF
--- a/xcom2-launcher/xcom2-launcher/Classes/Mod/ModList.cs
+++ b/xcom2-launcher/xcom2-launcher/Classes/Mod/ModList.cs
@@ -171,6 +171,12 @@ namespace XCOM2Launcher.Mod
                     $"A mod could not be loaded since it contains multiple .xcommod files\r\nPlease notify the mod creator.\r\n\r\nPath: {modDir}");
                 return null;
             }
+            catch (UnauthorizedAccessException)
+            {
+                // the user probably added a system folder or a root directory as mod folder
+                // where AML has no access rights to all or some of the sub-folders
+                return null;
+            }
 
             return infoFile;
         }

--- a/xcom2-launcher/xcom2-launcher/Classes/XCOM/XCOM2.cs
+++ b/xcom2-launcher/xcom2-launcher/Classes/XCOM/XCOM2.cs
@@ -130,7 +130,7 @@ namespace XCOM2Launcher.XCOM
                 new DefaultConfigFile("Engine").Get("Engine.DownloadableContentEnumerator", "ModRootDirs")?
                     .Select(
                         path => Path.IsPathRooted(path)
-                            ? path
+                            ? path.EndsWith(@"\") ? path : path + @"\"
                             : Path.GetFullPath(Path.Combine(GameDir, "bin", "Win64", path))
                     )
                     .Where(Directory.Exists)

--- a/xcom2-launcher/xcom2-launcher/Forms/SettingsDialog.cs
+++ b/xcom2-launcher/xcom2-launcher/Forms/SettingsDialog.cs
@@ -97,8 +97,11 @@ namespace XCOM2Launcher.Forms
             if (dialog.ShowDialog() != DialogResult.OK)
                 return;
 
-            Settings.ModPaths.Add(dialog.SelectedPath + "\\");
-            modPathsListbox.Items.Add(dialog.SelectedPath + "\\");
+            // make sure the mod path ends with a trailing backslash as required for entry in XCOM ini file
+            var path = dialog.SelectedPath.EndsWith(@"\") ? dialog.SelectedPath : dialog.SelectedPath + @"\";
+
+            Settings.ModPaths.Add(path);
+            modPathsListbox.Items.Add(path);
         }
 
         private void SettingsDialog_Shown(object sender, EventArgs e)


### PR DESCRIPTION
Resolves #55: Trailing double-backslash when adding root directories (c:\\).
Also fixes UnauthorizedAccessException for folders with insufficient access permissions and add some minor improvements.
See commit log for more details.