### PR TITLE
Mod category sorting and usability improvements

### DIFF
--- a/xcom2-launcher/xcom2-launcher/Classes/Mod/ModCategory.cs
+++ b/xcom2-launcher/xcom2-launcher/Classes/Mod/ModCategory.cs
@@ -1,13 +1,31 @@
 ﻿using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace XCOM2Launcher.Mod
 {
+    [JsonObject(MemberSerialization.OptIn)]
     public class ModCategory
     {
-        public int Index { get; set; } = -1;
+        [JsonProperty]
+        public int Index { get; set; }
+        
+        [JsonProperty]
+        public bool Collapsed { get; set; }
+        
+        [JsonProperty]
+        public List<ModEntry> Entries { get; }
 
-        public bool Collapsed { get; set; } = false;
+        // Parameterless constructor required for serialization
+        public ModCategory()
+        {
+            Index = -1;
+            Collapsed = false;
+            Entries = new List<ModEntry>();
+        }
 
-        public List<ModEntry> Entries { get; set; } = new List<ModEntry>();
+        public ModCategory(int index) : this()
+        {
+            Index = index;
+        }
     }
 }

--- a/xcom2-launcher/xcom2-launcher/Classes/Mod/ModList.cs
+++ b/xcom2-launcher/xcom2-launcher/Classes/Mod/ModList.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Web.Management;
 using System.Windows.Forms;
 using Newtonsoft.Json;
 using Steamworks;
@@ -26,7 +25,7 @@ namespace XCOM2Launcher.Mod
         public IEnumerable<ModEntry> All => Entries.SelectMany(c => c.Value.Entries);
 
         [JsonIgnore]
-        public IEnumerable<string> Categories => Entries.OrderBy(c => c.Value.Index).ThenBy(c => c.Key).Select(c => c.Key);
+        public IEnumerable<string> CategoryNames => Entries.OrderBy(c => c.Value.Index).ThenBy(c => c.Key).Select(c => c.Key);
 
         [JsonIgnore]
         public IEnumerable<ModEntry> Active => All.Where(m => m.isActive);
@@ -42,11 +41,23 @@ namespace XCOM2Launcher.Mod
 
                 if (cat == null)
                 {
-                    cat = new ModCategory();
+                    cat = new ModCategory(Entries.Max(entry => entry.Value.Index) + 1);
                     Entries.Add(category, cat);
                 }
 
                 return cat;
+            }
+        }
+
+        /// <summary>
+        /// Make sure category indices are numbered from 0..n without gaps.
+        /// </summary>
+        public void InitCategoryIndices()
+        {
+            var newIndex = 0;
+            foreach (var entry in Entries.OrderBy(entry => entry.Value.Index))
+            {
+                entry.Value.Index = newIndex++;
             }
         }
 

--- a/xcom2-launcher/xcom2-launcher/Forms/CategoryManager.cs
+++ b/xcom2-launcher/xcom2-launcher/Forms/CategoryManager.cs
@@ -23,7 +23,7 @@ namespace XCOM2Launcher.Forms
 
             Settings = settings;
 
-            foreach (var cat in settings.Mods.Categories)
+            foreach (var cat in settings.Mods.CategoryNames)
                 categoriesListBox.Items.Add(cat);
         }
 
@@ -34,15 +34,17 @@ namespace XCOM2Launcher.Forms
             if (string.IsNullOrEmpty(newName))
                 return;
 
+            var categories = Settings.Mods.CategoryNames.ToList();
+
             // If no category with the given name exists add it, otherweise select exiting entry.
-            if (!Settings.Mods.Categories.Contains(newName))
+            if (!categories.Contains(newName))
             {
                 Log.Info($"Adding category '{newName}'");
 
                 categoriesListBox.Items.Add(newName);
                 categoriesListBox.SelectedItem = newName;
 
-                Settings.Mods.Entries.Add(newName, new ModCategory());
+                Settings.Mods.Entries.Add(newName, new ModCategory(Settings.Mods.Entries.Max(entry => entry.Value.Index) + 1));
             }
             else
             {
@@ -75,6 +77,7 @@ namespace XCOM2Launcher.Forms
                 Settings.Mods.AddMod(ModInfo.DEFAULT_CATEGORY_NAME, m);
 
             Settings.Mods.Entries.Remove(category);
+            Settings.Mods.InitCategoryIndices();
             categoriesListBox.Items.RemoveAt(index);
         }
 

--- a/xcom2-launcher/xcom2-launcher/Forms/MainForm.Designer.cs
+++ b/xcom2-launcher/xcom2-launcher/Forms/MainForm.Designer.cs
@@ -634,11 +634,9 @@
             this.modlist_ListObjectListView.CellRightClick += new System.EventHandler<BrightIdeasSoftware.CellRightClickEventArgs>(this.ModListCellRightClick);
             this.modlist_ListObjectListView.CellToolTipShowing += new System.EventHandler<BrightIdeasSoftware.ToolTipShowingEventArgs>(this.ModListCellToolTipShowing);
             this.modlist_ListObjectListView.FormatRow += new System.EventHandler<BrightIdeasSoftware.FormatRowEventArgs>(this.ModListFormatRow);
-            this.modlist_ListObjectListView.GroupExpandingCollapsing += new System.EventHandler<BrightIdeasSoftware.GroupExpandingCollapsingEventArgs>(this.ModListGroupExpandingCollapsing);
             this.modlist_ListObjectListView.SelectionChanged += new System.EventHandler(this.ModListSelectionChanged);
             this.modlist_ListObjectListView.ItemChecked += new System.Windows.Forms.ItemCheckedEventHandler(this.ModListItemChecked);
             this.modlist_ListObjectListView.KeyDown += new System.Windows.Forms.KeyEventHandler(this.ModListKeyDown);
-            this.modlist_ListObjectListView.KeyUp += new System.Windows.Forms.KeyEventHandler(this.ModListKeyUp);
             // 
             // olvcActive
             // 

--- a/xcom2-launcher/xcom2-launcher/Forms/MainForm.Events.cs
+++ b/xcom2-launcher/xcom2-launcher/Forms/MainForm.Events.cs
@@ -260,7 +260,12 @@ namespace XCOM2Launcher.Forms
 
             if (result == DialogResult.OK)
             {
-                RefreshModList();
+                var collapsedGroups = modlist_ListObjectListView.CollapsedGroups.ToList();
+                modlist_ListObjectListView.BeginUpdate();
+                modlist_ListObjectListView.BuildGroups();
+                // Restore previously collapsed groups
+                collapsedGroups.ForEach(g => g.Collapsed = true);
+                modlist_ListObjectListView.EndUpdate();
             }
         }
 

--- a/xcom2-launcher/xcom2-launcher/Program.cs
+++ b/xcom2-launcher/xcom2-launcher/Program.cs
@@ -315,11 +315,7 @@ namespace XCOM2Launcher
             if (settings.Mods.Entries.Count > 0)
             {
                 settings.Mods.MarkDuplicates();
-
-                // Verify categories
-                var index = settings.Mods.Entries.Values.Max(c => c.Index);
-                foreach (var cat in settings.Mods.Entries.Values.Where(c => c.Index == -1))
-                    cat.Index = ++index;
+                settings.Mods.InitCategoryIndices();
 
                 // Verify Mods 
                 foreach (var mod in settings.Mods.All)


### PR DESCRIPTION
- Moving a mod to a collapsed category will no longer expand all categories. Resolves #176.
- Fixed category sort order inconsistencies. Resolves #177.
- Preserve mod list category grouping and selection after opening/closing the category manager.
- Fixed AML not properly saving the expanded/collapsed state for categories to restore those on application restart.