### PR TITLE
Add "readme.md" file extension support for Readme.

### DIFF
--- a/xcom2-launcher/xcom2-launcher/Classes/Mod/ModEntry.cs
+++ b/xcom2-launcher/xcom2-launcher/Classes/Mod/ModEntry.cs
@@ -423,27 +423,23 @@ namespace XCOM2Launcher.Mod
         {
             try
             {
+                var readmePathTxt = FilePath.Combine(Path, "ReadMe.txt");
+                var readmePathMd = FilePath.Combine(Path, "ReadMe.md");
+
+                if (File.Exists(readmePathTxt))
+                {
+                    return File.ReadAllText(readmePathTxt);
+                }
                 
-		var readmePathTXT = FilePath.Combine(Path, "ReadMe.txt");
-		var readmePathMD = FilePath.Combine(Path, "ReadMe.md");
+                if (File.Exists(readmePathMd))
+                {
+                    return File.ReadAllText(readmePathMd);
+                }
 
-		if (File.Exists(readmePathTXT)) {
-
-                	return File.ReadAllText(readmePathTXT);
-
-		} else if (File.Exists(readmePathMD)) {
-
-			return File.ReadAllText(readmePathMD);
-
-		} else {
-
-			return "No ReadMe found.";
-		}
-		    
-            }
+                return "No ReadMe found.";            }
             catch (Exception ex)
             {
-                return "Unable to access ReadMe.txt - " + ex.Message;
+                return "Unable to access ReadMe file - " + ex.Message;
             }
         }
 

--- a/xcom2-launcher/xcom2-launcher/Classes/Mod/ModEntry.cs
+++ b/xcom2-launcher/xcom2-launcher/Classes/Mod/ModEntry.cs
@@ -423,8 +423,23 @@ namespace XCOM2Launcher.Mod
         {
             try
             {
-                var readmePath = FilePath.Combine(Path, "ReadMe.txt");
-                return File.Exists(readmePath) ? File.ReadAllText(readmePath) : "No ReadMe found.";
+                
+		var readmePathTXT = FilePath.Combine(Path, "ReadMe.txt");
+		var readmePathMD = FilePath.Combine(Path, "ReadMe.md");
+
+		if (File.Exists(readmePathTXT)) {
+
+                	return File.ReadAllText(readmePathTXT);
+
+		} else if (File.Exists(readmePathMD)) {
+
+			return File.ReadAllText(readmePathMD);
+
+		} else {
+
+			return "No ReadMe found.";
+		}
+		    
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Current version only looks for "readme.txt" file to populate the readme section of the mod entry.

Many mods seem to be including "readme.md" files instead. So just added the ability to also look for and load this file in addition to readme.txt

Future versions might want to add a file extension agnostic method of handling readme files (eg. Readme files with any or no extension).