### PR TITLE
Fixes #332

### DIFF
--- a/xcom2-launcher/xcom2-launcher/Forms/AboutBox.Designer.cs
+++ b/xcom2-launcher/xcom2-launcher/Forms/AboutBox.Designer.cs
@@ -22,149 +22,149 @@
 		/// the contents of this method with the code editor.
 		/// </summary>
 		private void InitializeComponent() {
-			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(AboutBox));
-			this.tableLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
-			this.logoPictureBox = new System.Windows.Forms.PictureBox();
-			this.labelProductName = new System.Windows.Forms.Label();
-			this.labelVersion = new System.Windows.Forms.Label();
-			this.labelCopyright = new System.Windows.Forms.Label();
-			this.labelCompanyName = new System.Windows.Forms.Label();
-			this.textBoxDescription = new System.Windows.Forms.TextBox();
-			this.okButton = new System.Windows.Forms.Button();
-			this.tableLayoutPanel.SuspendLayout();
-			((System.ComponentModel.ISupportInitialize)(this.logoPictureBox)).BeginInit();
-			this.SuspendLayout();
-			// 
-			// tableLayoutPanel
-			// 
-			this.tableLayoutPanel.ColumnCount = 2;
-			this.tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 33.66336F));
-			this.tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 66.33663F));
-			this.tableLayoutPanel.Controls.Add(this.logoPictureBox, 0, 0);
-			this.tableLayoutPanel.Controls.Add(this.labelProductName, 1, 0);
-			this.tableLayoutPanel.Controls.Add(this.labelVersion, 1, 1);
-			this.tableLayoutPanel.Controls.Add(this.labelCopyright, 1, 2);
-			this.tableLayoutPanel.Controls.Add(this.labelCompanyName, 1, 3);
-			this.tableLayoutPanel.Controls.Add(this.textBoxDescription, 1, 4);
-			this.tableLayoutPanel.Controls.Add(this.okButton, 1, 5);
-			this.tableLayoutPanel.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.tableLayoutPanel.Location = new System.Drawing.Point(9, 9);
-			this.tableLayoutPanel.Name = "tableLayoutPanel";
-			this.tableLayoutPanel.RowCount = 6;
-			this.tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 10F));
-			this.tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 10F));
-			this.tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 10F));
-			this.tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 10F));
-			this.tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
-			this.tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 10F));
-			this.tableLayoutPanel.Size = new System.Drawing.Size(360, 265);
-			this.tableLayoutPanel.TabIndex = 0;
-			// 
-			// logoPictureBox
-			// 
-			this.logoPictureBox.Image = ((System.Drawing.Image)(resources.GetObject("logoPictureBox.Image")));
-			this.logoPictureBox.Location = new System.Drawing.Point(3, 3);
-			this.logoPictureBox.Name = "logoPictureBox";
-			this.tableLayoutPanel.SetRowSpan(this.logoPictureBox, 6);
-			this.logoPictureBox.Size = new System.Drawing.Size(115, 259);
-			this.logoPictureBox.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
-			this.logoPictureBox.TabIndex = 12;
-			this.logoPictureBox.TabStop = false;
-			// 
-			// labelProductName
-			// 
-			this.labelProductName.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.labelProductName.Location = new System.Drawing.Point(127, 5);
-			this.labelProductName.Margin = new System.Windows.Forms.Padding(6, 5, 3, 0);
-			this.labelProductName.MaximumSize = new System.Drawing.Size(0, 17);
-			this.labelProductName.Name = "labelProductName";
-			this.labelProductName.Size = new System.Drawing.Size(230, 17);
-			this.labelProductName.TabIndex = 19;
-			this.labelProductName.Text = "Product Name";
-			this.labelProductName.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// labelVersion
-			// 
-			this.labelVersion.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.labelVersion.Location = new System.Drawing.Point(127, 31);
-			this.labelVersion.Margin = new System.Windows.Forms.Padding(6, 5, 3, 0);
-			this.labelVersion.MaximumSize = new System.Drawing.Size(0, 17);
-			this.labelVersion.Name = "labelVersion";
-			this.labelVersion.Size = new System.Drawing.Size(230, 17);
-			this.labelVersion.TabIndex = 0;
-			this.labelVersion.Text = "Version";
-			this.labelVersion.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// labelCopyright
-			// 
-			this.labelCopyright.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.labelCopyright.Location = new System.Drawing.Point(127, 57);
-			this.labelCopyright.Margin = new System.Windows.Forms.Padding(6, 5, 3, 0);
-			this.labelCopyright.MaximumSize = new System.Drawing.Size(0, 17);
-			this.labelCopyright.Name = "labelCopyright";
-			this.labelCopyright.Size = new System.Drawing.Size(230, 17);
-			this.labelCopyright.TabIndex = 21;
-			this.labelCopyright.Text = "Copyright";
-			this.labelCopyright.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// labelCompanyName
-			// 
-			this.labelCompanyName.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.labelCompanyName.Location = new System.Drawing.Point(127, 83);
-			this.labelCompanyName.Margin = new System.Windows.Forms.Padding(6, 5, 3, 0);
-			this.labelCompanyName.MaximumSize = new System.Drawing.Size(0, 17);
-			this.labelCompanyName.Name = "labelCompanyName";
-			this.labelCompanyName.Size = new System.Drawing.Size(230, 17);
-			this.labelCompanyName.TabIndex = 22;
-			this.labelCompanyName.Text = "Company Name";
-			this.labelCompanyName.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// textBoxDescription
-			// 
-			this.textBoxDescription.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.textBoxDescription.Location = new System.Drawing.Point(127, 107);
-			this.textBoxDescription.Margin = new System.Windows.Forms.Padding(6, 3, 3, 3);
-			this.textBoxDescription.Multiline = true;
-			this.textBoxDescription.Name = "textBoxDescription";
-			this.textBoxDescription.ReadOnly = true;
-			this.textBoxDescription.ScrollBars = System.Windows.Forms.ScrollBars.Both;
-			this.textBoxDescription.Size = new System.Drawing.Size(230, 126);
-			this.textBoxDescription.TabIndex = 23;
-			this.textBoxDescription.TabStop = false;
-			this.textBoxDescription.Text = "Description";
-			// 
-			// okButton
-			// 
-			this.okButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-			this.okButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-			this.okButton.Location = new System.Drawing.Point(282, 239);
-			this.okButton.Name = "okButton";
-			this.okButton.Size = new System.Drawing.Size(75, 23);
-			this.okButton.TabIndex = 24;
-			this.okButton.Text = "&OK";
-			// 
-			// AboutBox
-			// 
-			this.AcceptButton = this.okButton;
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.ClientSize = new System.Drawing.Size(378, 283);
-			this.Controls.Add(this.tableLayoutPanel);
-			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
-			this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-			this.MaximizeBox = false;
-			this.MinimizeBox = false;
-			this.Name = "AboutBox";
-			this.Padding = new System.Windows.Forms.Padding(9);
-			this.ShowIcon = false;
-			this.ShowInTaskbar = false;
-			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-			this.Text = "AboutBox";
-			this.Load += new System.EventHandler(this.AboutBox_Load);
-			this.tableLayoutPanel.ResumeLayout(false);
-			this.tableLayoutPanel.PerformLayout();
-			((System.ComponentModel.ISupportInitialize)(this.logoPictureBox)).EndInit();
-			this.ResumeLayout(false);
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(AboutBox));
+            this.tableLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
+            this.logoPictureBox = new System.Windows.Forms.PictureBox();
+            this.labelProductName = new System.Windows.Forms.Label();
+            this.labelVersion = new System.Windows.Forms.Label();
+            this.labelCopyright = new System.Windows.Forms.Label();
+            this.labelCompanyName = new System.Windows.Forms.Label();
+            this.textBoxDescription = new System.Windows.Forms.TextBox();
+            this.okButton = new System.Windows.Forms.Button();
+            this.tableLayoutPanel.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.logoPictureBox)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // tableLayoutPanel
+            // 
+            this.tableLayoutPanel.ColumnCount = 2;
+            this.tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 33.66336F));
+            this.tableLayoutPanel.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 66.33663F));
+            this.tableLayoutPanel.Controls.Add(this.logoPictureBox, 0, 0);
+            this.tableLayoutPanel.Controls.Add(this.labelProductName, 1, 0);
+            this.tableLayoutPanel.Controls.Add(this.labelVersion, 1, 1);
+            this.tableLayoutPanel.Controls.Add(this.labelCopyright, 1, 2);
+            this.tableLayoutPanel.Controls.Add(this.labelCompanyName, 1, 3);
+            this.tableLayoutPanel.Controls.Add(this.textBoxDescription, 1, 4);
+            this.tableLayoutPanel.Controls.Add(this.okButton, 1, 5);
+            this.tableLayoutPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel.Location = new System.Drawing.Point(9, 9);
+            this.tableLayoutPanel.Name = "tableLayoutPanel";
+            this.tableLayoutPanel.RowCount = 6;
+            this.tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 10F));
+            this.tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 10F));
+            this.tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 10F));
+            this.tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 10F));
+            this.tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.tableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 10F));
+            this.tableLayoutPanel.Size = new System.Drawing.Size(360, 265);
+            this.tableLayoutPanel.TabIndex = 0;
+            // 
+            // logoPictureBox
+            // 
+            this.logoPictureBox.Image = ((System.Drawing.Image)(resources.GetObject("logoPictureBox.Image")));
+            this.logoPictureBox.Location = new System.Drawing.Point(3, 3);
+            this.logoPictureBox.Name = "logoPictureBox";
+            this.tableLayoutPanel.SetRowSpan(this.logoPictureBox, 6);
+            this.logoPictureBox.Size = new System.Drawing.Size(115, 259);
+            this.logoPictureBox.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
+            this.logoPictureBox.TabIndex = 12;
+            this.logoPictureBox.TabStop = false;
+            // 
+            // labelProductName
+            // 
+            this.labelProductName.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.labelProductName.Location = new System.Drawing.Point(127, 5);
+            this.labelProductName.Margin = new System.Windows.Forms.Padding(6, 5, 3, 0);
+            this.labelProductName.MaximumSize = new System.Drawing.Size(0, 17);
+            this.labelProductName.Name = "labelProductName";
+            this.labelProductName.Size = new System.Drawing.Size(230, 17);
+            this.labelProductName.TabIndex = 19;
+            this.labelProductName.Text = "Product Name";
+            this.labelProductName.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // labelVersion
+            // 
+            this.labelVersion.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.labelVersion.Location = new System.Drawing.Point(127, 31);
+            this.labelVersion.Margin = new System.Windows.Forms.Padding(6, 5, 3, 0);
+            this.labelVersion.MaximumSize = new System.Drawing.Size(0, 17);
+            this.labelVersion.Name = "labelVersion";
+            this.labelVersion.Size = new System.Drawing.Size(230, 17);
+            this.labelVersion.TabIndex = 0;
+            this.labelVersion.Text = "Version";
+            this.labelVersion.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // labelCopyright
+            // 
+            this.labelCopyright.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.labelCopyright.Location = new System.Drawing.Point(127, 57);
+            this.labelCopyright.Margin = new System.Windows.Forms.Padding(6, 5, 3, 0);
+            this.labelCopyright.MaximumSize = new System.Drawing.Size(0, 17);
+            this.labelCopyright.Name = "labelCopyright";
+            this.labelCopyright.Size = new System.Drawing.Size(230, 17);
+            this.labelCopyright.TabIndex = 21;
+            this.labelCopyright.Text = "Copyright";
+            this.labelCopyright.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // labelCompanyName
+            // 
+            this.labelCompanyName.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.labelCompanyName.Location = new System.Drawing.Point(127, 83);
+            this.labelCompanyName.Margin = new System.Windows.Forms.Padding(6, 5, 3, 0);
+            this.labelCompanyName.MaximumSize = new System.Drawing.Size(0, 17);
+            this.labelCompanyName.Name = "labelCompanyName";
+            this.labelCompanyName.Size = new System.Drawing.Size(230, 17);
+            this.labelCompanyName.TabIndex = 22;
+            this.labelCompanyName.Text = "Company Name";
+            this.labelCompanyName.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // textBoxDescription
+            // 
+            this.textBoxDescription.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.textBoxDescription.Location = new System.Drawing.Point(127, 107);
+            this.textBoxDescription.Margin = new System.Windows.Forms.Padding(6, 3, 3, 3);
+            this.textBoxDescription.Multiline = true;
+            this.textBoxDescription.Name = "textBoxDescription";
+            this.textBoxDescription.ReadOnly = true;
+            this.textBoxDescription.ScrollBars = System.Windows.Forms.ScrollBars.Both;
+            this.textBoxDescription.Size = new System.Drawing.Size(230, 126);
+            this.textBoxDescription.TabIndex = 23;
+            this.textBoxDescription.TabStop = false;
+            this.textBoxDescription.Text = "Description";
+            // 
+            // okButton
+            // 
+            this.okButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.okButton.DialogResult = System.Windows.Forms.DialogResult.OK;
+            this.okButton.Location = new System.Drawing.Point(282, 239);
+            this.okButton.Name = "okButton";
+            this.okButton.Size = new System.Drawing.Size(75, 23);
+            this.okButton.TabIndex = 24;
+            this.okButton.Text = "&Close";
+            // 
+            // AboutBox
+            // 
+            this.AcceptButton = this.okButton;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(378, 283);
+            this.Controls.Add(this.tableLayoutPanel);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "AboutBox";
+            this.Padding = new System.Windows.Forms.Padding(9);
+            this.ShowIcon = false;
+            this.ShowInTaskbar = false;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "AboutBox";
+            this.Load += new System.EventHandler(this.AboutBox_Load);
+            this.tableLayoutPanel.ResumeLayout(false);
+            this.tableLayoutPanel.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.logoPictureBox)).EndInit();
+            this.ResumeLayout(false);
 
 		}
 

--- a/xcom2-launcher/xcom2-launcher/Forms/AboutBox.cs
+++ b/xcom2-launcher/xcom2-launcher/Forms/AboutBox.cs
@@ -9,6 +9,7 @@ namespace XCOM2Launcher.Forms
         public AboutBox()
         {
             InitializeComponent();
+            CancelButton = okButton;
         }
 
         private void AboutBox_Load(object sender, EventArgs e)

--- a/xcom2-launcher/xcom2-launcher/Forms/CategoryManager.cs
+++ b/xcom2-launcher/xcom2-launcher/Forms/CategoryManager.cs
@@ -20,7 +20,8 @@ namespace XCOM2Launcher.Forms
         public CategoryManager(Settings settings)
         {
             InitializeComponent();
-
+            
+            CancelButton = bClose;
             Settings = settings;
 
             foreach (var cat in settings.Mods.CategoryNames)

--- a/xcom2-launcher/xcom2-launcher/Forms/CleanModsForm.Designer.cs
+++ b/xcom2-launcher/xcom2-launcher/Forms/CleanModsForm.Designer.cs
@@ -28,190 +28,203 @@
         /// </summary>
         private void InitializeComponent()
         {
-			this.components = new System.ComponentModel.Container();
-			this.button1 = new System.Windows.Forms.Button();
-			this.groupBox1 = new System.Windows.Forms.GroupBox();
-			this.shader_groupbox = new System.Windows.Forms.GroupBox();
-			this.shadercache_none_radiobutton = new System.Windows.Forms.RadioButton();
-			this.shadercache_empty_radiobutton = new System.Windows.Forms.RadioButton();
-			this.shadercache_all_radiobutton = new System.Windows.Forms.RadioButton();
-			this.button3 = new System.Windows.Forms.Button();
-			this.source_groupbox = new System.Windows.Forms.GroupBox();
-			this.src_all_radiobutton = new System.Windows.Forms.RadioButton();
-			this.src_xcomgame_radiobutton = new System.Windows.Forms.RadioButton();
-			this.src_none_radiobutton = new System.Windows.Forms.RadioButton();
-			this.button2 = new System.Windows.Forms.Button();
-			this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
-			this.groupBox1.SuspendLayout();
-			this.shader_groupbox.SuspendLayout();
-			this.source_groupbox.SuspendLayout();
-			this.SuspendLayout();
-			// 
-			// button1
-			// 
-			this.button1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.button1.Location = new System.Drawing.Point(296, 135);
-			this.button1.Name = "button1";
-			this.button1.Size = new System.Drawing.Size(75, 23);
-			this.button1.TabIndex = 7;
-			this.button1.Text = "Start";
-			this.button1.UseVisualStyleBackColor = true;
-			// 
-			// groupBox1
-			// 
-			this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.components = new System.ComponentModel.Container();
+            this.bStart = new System.Windows.Forms.Button();
+            this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.shader_groupbox = new System.Windows.Forms.GroupBox();
+            this.shadercache_none_radiobutton = new System.Windows.Forms.RadioButton();
+            this.shadercache_empty_radiobutton = new System.Windows.Forms.RadioButton();
+            this.shadercache_all_radiobutton = new System.Windows.Forms.RadioButton();
+            this.button3 = new System.Windows.Forms.Button();
+            this.source_groupbox = new System.Windows.Forms.GroupBox();
+            this.src_all_radiobutton = new System.Windows.Forms.RadioButton();
+            this.src_xcomgame_radiobutton = new System.Windows.Forms.RadioButton();
+            this.src_none_radiobutton = new System.Windows.Forms.RadioButton();
+            this.button2 = new System.Windows.Forms.Button();
+            this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
+            this.bClose = new System.Windows.Forms.Button();
+            this.groupBox1.SuspendLayout();
+            this.shader_groupbox.SuspendLayout();
+            this.source_groupbox.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // bStart
+            // 
+            this.bStart.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.bStart.Location = new System.Drawing.Point(215, 135);
+            this.bStart.Name = "bStart";
+            this.bStart.Size = new System.Drawing.Size(75, 23);
+            this.bStart.TabIndex = 7;
+            this.bStart.Text = "&Start";
+            this.bStart.UseVisualStyleBackColor = true;
+            // 
+            // groupBox1
+            // 
+            this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.groupBox1.Controls.Add(this.shader_groupbox);
-			this.groupBox1.Controls.Add(this.source_groupbox);
-			this.groupBox1.Location = new System.Drawing.Point(12, 12);
-			this.groupBox1.Name = "groupBox1";
-			this.groupBox1.Size = new System.Drawing.Size(359, 116);
-			this.groupBox1.TabIndex = 3;
-			this.groupBox1.TabStop = false;
-			this.groupBox1.Text = "Deletion settings";
-			// 
-			// shader_groupbox
-			// 
-			this.shader_groupbox.Controls.Add(this.shadercache_none_radiobutton);
-			this.shader_groupbox.Controls.Add(this.shadercache_empty_radiobutton);
-			this.shader_groupbox.Controls.Add(this.shadercache_all_radiobutton);
-			this.shader_groupbox.Controls.Add(this.button3);
-			this.shader_groupbox.Enabled = false;
-			this.shader_groupbox.Location = new System.Drawing.Point(182, 19);
-			this.shader_groupbox.Name = "shader_groupbox";
-			this.shader_groupbox.Size = new System.Drawing.Size(170, 91);
-			this.shader_groupbox.TabIndex = 6;
-			this.shader_groupbox.TabStop = false;
-			this.shader_groupbox.Text = "ModShaderCache files";
-			// 
-			// shadercache_none_radiobutton
-			// 
-			this.shadercache_none_radiobutton.AutoSize = true;
-			this.shadercache_none_radiobutton.Enabled = false;
-			this.shadercache_none_radiobutton.Location = new System.Drawing.Point(6, 19);
-			this.shadercache_none_radiobutton.Name = "shadercache_none_radiobutton";
-			this.shadercache_none_radiobutton.Size = new System.Drawing.Size(51, 17);
-			this.shadercache_none_radiobutton.TabIndex = 4;
-			this.shadercache_none_radiobutton.Text = "None";
-			this.toolTip1.SetToolTip(this.shadercache_none_radiobutton, "Do not delete anything.");
-			this.shadercache_none_radiobutton.UseVisualStyleBackColor = true;
-			// 
-			// shadercache_empty_radiobutton
-			// 
-			this.shadercache_empty_radiobutton.AutoSize = true;
-			this.shadercache_empty_radiobutton.Checked = true;
-			this.shadercache_empty_radiobutton.Enabled = false;
-			this.shadercache_empty_radiobutton.Location = new System.Drawing.Point(6, 42);
-			this.shadercache_empty_radiobutton.Name = "shadercache_empty_radiobutton";
-			this.shadercache_empty_radiobutton.Size = new System.Drawing.Size(54, 17);
-			this.shadercache_empty_radiobutton.TabIndex = 5;
-			this.shadercache_empty_radiobutton.TabStop = true;
-			this.shadercache_empty_radiobutton.Text = "Empty";
-			this.toolTip1.SetToolTip(this.shadercache_empty_radiobutton, "Safe.");
-			this.shadercache_empty_radiobutton.UseVisualStyleBackColor = true;
-			// 
-			// shadercache_all_radiobutton
-			// 
-			this.shadercache_all_radiobutton.AutoSize = true;
-			this.shadercache_all_radiobutton.Enabled = false;
-			this.shadercache_all_radiobutton.Location = new System.Drawing.Point(6, 65);
-			this.shadercache_all_radiobutton.Name = "shadercache_all_radiobutton";
-			this.shadercache_all_radiobutton.Size = new System.Drawing.Size(36, 17);
-			this.shadercache_all_radiobutton.TabIndex = 6;
-			this.shadercache_all_radiobutton.Text = "All";
-			this.toolTip1.SetToolTip(this.shadercache_all_radiobutton, "NOT SAFE. This can/will cause graphical glitches.");
-			this.shadercache_all_radiobutton.UseVisualStyleBackColor = true;
-			// 
-			// button3
-			// 
-			this.button3.Location = new System.Drawing.Point(303, 75);
-			this.button3.Name = "button3";
-			this.button3.Size = new System.Drawing.Size(75, 23);
-			this.button3.TabIndex = 0;
-			this.button3.Text = "Start";
-			this.button3.UseVisualStyleBackColor = true;
-			// 
-			// source_groupbox
-			// 
-			this.source_groupbox.Controls.Add(this.src_all_radiobutton);
-			this.source_groupbox.Controls.Add(this.src_xcomgame_radiobutton);
-			this.source_groupbox.Controls.Add(this.src_none_radiobutton);
-			this.source_groupbox.Controls.Add(this.button2);
-			this.source_groupbox.Location = new System.Drawing.Point(6, 19);
-			this.source_groupbox.Name = "source_groupbox";
-			this.source_groupbox.Size = new System.Drawing.Size(170, 91);
-			this.source_groupbox.TabIndex = 4;
-			this.source_groupbox.TabStop = false;
-			this.source_groupbox.Text = "Source files";
-			this.toolTip1.SetToolTip(this.source_groupbox, "Source files are only relevant for mod creators.");
-			// 
-			// src_all_radiobutton
-			// 
-			this.src_all_radiobutton.AutoSize = true;
-			this.src_all_radiobutton.Location = new System.Drawing.Point(6, 19);
-			this.src_all_radiobutton.Name = "src_all_radiobutton";
-			this.src_all_radiobutton.Size = new System.Drawing.Size(51, 17);
-			this.src_all_radiobutton.TabIndex = 1;
-			this.src_all_radiobutton.Text = "None";
-			this.toolTip1.SetToolTip(this.src_all_radiobutton, "Do not delete anything.");
-			this.src_all_radiobutton.UseVisualStyleBackColor = true;
-			// 
-			// src_xcomgame_radiobutton
-			// 
-			this.src_xcomgame_radiobutton.AutoSize = true;
-			this.src_xcomgame_radiobutton.Checked = true;
-			this.src_xcomgame_radiobutton.Location = new System.Drawing.Point(6, 42);
-			this.src_xcomgame_radiobutton.Name = "src_xcomgame_radiobutton";
-			this.src_xcomgame_radiobutton.Size = new System.Drawing.Size(81, 17);
-			this.src_xcomgame_radiobutton.TabIndex = 2;
-			this.src_xcomgame_radiobutton.TabStop = true;
-			this.src_xcomgame_radiobutton.Text = "XComGame";
-			this.toolTip1.SetToolTip(this.src_xcomgame_radiobutton, "Only delete src/XComGame files.");
-			this.src_xcomgame_radiobutton.UseVisualStyleBackColor = true;
-			// 
-			// src_none_radiobutton
-			// 
-			this.src_none_radiobutton.AutoSize = true;
-			this.src_none_radiobutton.Location = new System.Drawing.Point(6, 65);
-			this.src_none_radiobutton.Name = "src_none_radiobutton";
-			this.src_none_radiobutton.Size = new System.Drawing.Size(36, 17);
-			this.src_none_radiobutton.TabIndex = 3;
-			this.src_none_radiobutton.Text = "All";
-			this.toolTip1.SetToolTip(this.src_none_radiobutton, "Delete all source files.");
-			this.src_none_radiobutton.UseVisualStyleBackColor = true;
-			// 
-			// button2
-			// 
-			this.button2.Location = new System.Drawing.Point(303, 75);
-			this.button2.Name = "button2";
-			this.button2.Size = new System.Drawing.Size(75, 23);
-			this.button2.TabIndex = 0;
-			this.button2.Text = "Start";
-			this.button2.UseVisualStyleBackColor = true;
-			// 
-			// CleanModsForm
-			// 
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.ClientSize = new System.Drawing.Size(383, 165);
-			this.Controls.Add(this.button1);
-			this.Controls.Add(this.groupBox1);
-			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
-			this.Icon = global::XCOM2Launcher.Properties.Resources.xcom;
-			this.Name = "CleanModsForm";
-			this.Text = "Clean mods";
-			this.groupBox1.ResumeLayout(false);
-			this.shader_groupbox.ResumeLayout(false);
-			this.shader_groupbox.PerformLayout();
-			this.source_groupbox.ResumeLayout(false);
-			this.source_groupbox.PerformLayout();
-			this.ResumeLayout(false);
+            this.groupBox1.Controls.Add(this.shader_groupbox);
+            this.groupBox1.Controls.Add(this.source_groupbox);
+            this.groupBox1.Location = new System.Drawing.Point(12, 12);
+            this.groupBox1.Name = "groupBox1";
+            this.groupBox1.Size = new System.Drawing.Size(359, 116);
+            this.groupBox1.TabIndex = 3;
+            this.groupBox1.TabStop = false;
+            this.groupBox1.Text = "Deletion settings";
+            // 
+            // shader_groupbox
+            // 
+            this.shader_groupbox.Controls.Add(this.shadercache_none_radiobutton);
+            this.shader_groupbox.Controls.Add(this.shadercache_empty_radiobutton);
+            this.shader_groupbox.Controls.Add(this.shadercache_all_radiobutton);
+            this.shader_groupbox.Controls.Add(this.button3);
+            this.shader_groupbox.Enabled = false;
+            this.shader_groupbox.Location = new System.Drawing.Point(182, 19);
+            this.shader_groupbox.Name = "shader_groupbox";
+            this.shader_groupbox.Size = new System.Drawing.Size(170, 91);
+            this.shader_groupbox.TabIndex = 6;
+            this.shader_groupbox.TabStop = false;
+            this.shader_groupbox.Text = "ModShaderCache files";
+            // 
+            // shadercache_none_radiobutton
+            // 
+            this.shadercache_none_radiobutton.AutoSize = true;
+            this.shadercache_none_radiobutton.Enabled = false;
+            this.shadercache_none_radiobutton.Location = new System.Drawing.Point(6, 19);
+            this.shadercache_none_radiobutton.Name = "shadercache_none_radiobutton";
+            this.shadercache_none_radiobutton.Size = new System.Drawing.Size(51, 17);
+            this.shadercache_none_radiobutton.TabIndex = 4;
+            this.shadercache_none_radiobutton.Text = "None";
+            this.toolTip1.SetToolTip(this.shadercache_none_radiobutton, "Do not delete anything.");
+            this.shadercache_none_radiobutton.UseVisualStyleBackColor = true;
+            // 
+            // shadercache_empty_radiobutton
+            // 
+            this.shadercache_empty_radiobutton.AutoSize = true;
+            this.shadercache_empty_radiobutton.Checked = true;
+            this.shadercache_empty_radiobutton.Enabled = false;
+            this.shadercache_empty_radiobutton.Location = new System.Drawing.Point(6, 42);
+            this.shadercache_empty_radiobutton.Name = "shadercache_empty_radiobutton";
+            this.shadercache_empty_radiobutton.Size = new System.Drawing.Size(54, 17);
+            this.shadercache_empty_radiobutton.TabIndex = 5;
+            this.shadercache_empty_radiobutton.TabStop = true;
+            this.shadercache_empty_radiobutton.Text = "Empty";
+            this.toolTip1.SetToolTip(this.shadercache_empty_radiobutton, "Safe.");
+            this.shadercache_empty_radiobutton.UseVisualStyleBackColor = true;
+            // 
+            // shadercache_all_radiobutton
+            // 
+            this.shadercache_all_radiobutton.AutoSize = true;
+            this.shadercache_all_radiobutton.Enabled = false;
+            this.shadercache_all_radiobutton.Location = new System.Drawing.Point(6, 65);
+            this.shadercache_all_radiobutton.Name = "shadercache_all_radiobutton";
+            this.shadercache_all_radiobutton.Size = new System.Drawing.Size(36, 17);
+            this.shadercache_all_radiobutton.TabIndex = 6;
+            this.shadercache_all_radiobutton.Text = "All";
+            this.toolTip1.SetToolTip(this.shadercache_all_radiobutton, "NOT SAFE. This can/will cause graphical glitches.");
+            this.shadercache_all_radiobutton.UseVisualStyleBackColor = true;
+            // 
+            // button3
+            // 
+            this.button3.Location = new System.Drawing.Point(303, 75);
+            this.button3.Name = "button3";
+            this.button3.Size = new System.Drawing.Size(75, 23);
+            this.button3.TabIndex = 0;
+            this.button3.Text = "Start";
+            this.button3.UseVisualStyleBackColor = true;
+            // 
+            // source_groupbox
+            // 
+            this.source_groupbox.Controls.Add(this.src_all_radiobutton);
+            this.source_groupbox.Controls.Add(this.src_xcomgame_radiobutton);
+            this.source_groupbox.Controls.Add(this.src_none_radiobutton);
+            this.source_groupbox.Controls.Add(this.button2);
+            this.source_groupbox.Location = new System.Drawing.Point(6, 19);
+            this.source_groupbox.Name = "source_groupbox";
+            this.source_groupbox.Size = new System.Drawing.Size(170, 91);
+            this.source_groupbox.TabIndex = 4;
+            this.source_groupbox.TabStop = false;
+            this.source_groupbox.Text = "Source files";
+            this.toolTip1.SetToolTip(this.source_groupbox, "Source files are only relevant for mod creators.");
+            // 
+            // src_all_radiobutton
+            // 
+            this.src_all_radiobutton.AutoSize = true;
+            this.src_all_radiobutton.Location = new System.Drawing.Point(6, 19);
+            this.src_all_radiobutton.Name = "src_all_radiobutton";
+            this.src_all_radiobutton.Size = new System.Drawing.Size(51, 17);
+            this.src_all_radiobutton.TabIndex = 1;
+            this.src_all_radiobutton.Text = "None";
+            this.toolTip1.SetToolTip(this.src_all_radiobutton, "Do not delete anything.");
+            this.src_all_radiobutton.UseVisualStyleBackColor = true;
+            // 
+            // src_xcomgame_radiobutton
+            // 
+            this.src_xcomgame_radiobutton.AutoSize = true;
+            this.src_xcomgame_radiobutton.Checked = true;
+            this.src_xcomgame_radiobutton.Location = new System.Drawing.Point(6, 42);
+            this.src_xcomgame_radiobutton.Name = "src_xcomgame_radiobutton";
+            this.src_xcomgame_radiobutton.Size = new System.Drawing.Size(81, 17);
+            this.src_xcomgame_radiobutton.TabIndex = 2;
+            this.src_xcomgame_radiobutton.TabStop = true;
+            this.src_xcomgame_radiobutton.Text = "XComGame";
+            this.toolTip1.SetToolTip(this.src_xcomgame_radiobutton, "Only delete src/XComGame files.");
+            this.src_xcomgame_radiobutton.UseVisualStyleBackColor = true;
+            // 
+            // src_none_radiobutton
+            // 
+            this.src_none_radiobutton.AutoSize = true;
+            this.src_none_radiobutton.Location = new System.Drawing.Point(6, 65);
+            this.src_none_radiobutton.Name = "src_none_radiobutton";
+            this.src_none_radiobutton.Size = new System.Drawing.Size(36, 17);
+            this.src_none_radiobutton.TabIndex = 3;
+            this.src_none_radiobutton.Text = "All";
+            this.toolTip1.SetToolTip(this.src_none_radiobutton, "Delete all source files.");
+            this.src_none_radiobutton.UseVisualStyleBackColor = true;
+            // 
+            // button2
+            // 
+            this.button2.Location = new System.Drawing.Point(303, 75);
+            this.button2.Name = "button2";
+            this.button2.Size = new System.Drawing.Size(75, 23);
+            this.button2.TabIndex = 0;
+            this.button2.Text = "Start";
+            this.button2.UseVisualStyleBackColor = true;
+            // 
+            // bClose
+            // 
+            this.bClose.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.bClose.DialogResult = System.Windows.Forms.DialogResult.OK;
+            this.bClose.Location = new System.Drawing.Point(296, 135);
+            this.bClose.Name = "bClose";
+            this.bClose.Size = new System.Drawing.Size(75, 23);
+            this.bClose.TabIndex = 8;
+            this.bClose.Text = "&Close";
+            this.bClose.UseVisualStyleBackColor = true;
+            // 
+            // CleanModsForm
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(383, 165);
+            this.Controls.Add(this.bClose);
+            this.Controls.Add(this.bStart);
+            this.Controls.Add(this.groupBox1);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            this.Icon = global::XCOM2Launcher.Properties.Resources.xcom;
+            this.Name = "CleanModsForm";
+            this.Text = "Clean mods";
+            this.groupBox1.ResumeLayout(false);
+            this.shader_groupbox.ResumeLayout(false);
+            this.shader_groupbox.PerformLayout();
+            this.source_groupbox.ResumeLayout(false);
+            this.source_groupbox.PerformLayout();
+            this.ResumeLayout(false);
 
         }
 
         #endregion
 
-        private System.Windows.Forms.Button button1;
+        private System.Windows.Forms.Button bStart;
         private System.Windows.Forms.GroupBox groupBox1;
         private System.Windows.Forms.GroupBox source_groupbox;
         private System.Windows.Forms.RadioButton src_xcomgame_radiobutton;
@@ -224,5 +237,6 @@
         private System.Windows.Forms.RadioButton shadercache_all_radiobutton;
         private System.Windows.Forms.Button button3;
         private System.Windows.Forms.ToolTip toolTip1;
+        private System.Windows.Forms.Button bClose;
     }
 }

--- a/xcom2-launcher/xcom2-launcher/Forms/CleanModsForm.cs
+++ b/xcom2-launcher/xcom2-launcher/Forms/CleanModsForm.cs
@@ -12,12 +12,12 @@ namespace XCOM2Launcher.Forms
         {
             InitializeComponent();
 
-            // 
+            CancelButton = bClose;
             Mods = settings.Mods;
 
             // todo save cleaning settings?
             // Register Events
-            button1.Click += onStartButtonClicked;
+            bStart.Click += onStartButtonClicked;
         }
 
         private ModList Mods { get; }

--- a/xcom2-launcher/xcom2-launcher/Forms/ConfigDiff.Designer.cs
+++ b/xcom2-launcher/xcom2-launcher/Forms/ConfigDiff.Designer.cs
@@ -28,85 +28,86 @@
 		/// </summary>
 		private void InitializeComponent()
 		{
-			this.components = new System.ComponentModel.Container();
-			this.label6 = new System.Windows.Forms.Label();
-			this.label7 = new System.Windows.Forms.Label();
-			this.label5 = new System.Windows.Forms.Label();
-			this.label4 = new System.Windows.Forms.Label();
-			this.ofdFile = new System.Windows.Forms.OpenFileDialog();
-			this.btCompare = new System.Windows.Forms.Button();
-			this.fctb1 = new FastColoredTextBoxNS.FastColoredTextBox();
-			this.fctb2 = new FastColoredTextBoxNS.FastColoredTextBox();
-			this.splitContainer1 = new System.Windows.Forms.SplitContainer();
-			this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-			this.label1 = new System.Windows.Forms.Label();
-			this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
-			this.label2 = new System.Windows.Forms.Label();
-			((System.ComponentModel.ISupportInitialize)(this.fctb1)).BeginInit();
-			((System.ComponentModel.ISupportInitialize)(this.fctb2)).BeginInit();
-			((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
-			this.splitContainer1.Panel1.SuspendLayout();
-			this.splitContainer1.Panel2.SuspendLayout();
-			this.splitContainer1.SuspendLayout();
-			this.tableLayoutPanel1.SuspendLayout();
-			this.tableLayoutPanel2.SuspendLayout();
-			this.SuspendLayout();
-			// 
-			// label6
-			// 
-			this.label6.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-			this.label6.AutoSize = true;
-			this.label6.Location = new System.Drawing.Point(136, 415);
-			this.label6.Name = "label6";
-			this.label6.Size = new System.Drawing.Size(68, 13);
-			this.label6.TabIndex = 24;
-			this.label6.Text = "Deleted lines";
-			// 
-			// label7
-			// 
-			this.label7.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-			this.label7.BackColor = System.Drawing.Color.Pink;
-			this.label7.Location = new System.Drawing.Point(118, 415);
-			this.label7.Name = "label7";
-			this.label7.Size = new System.Drawing.Size(12, 13);
-			this.label7.TabIndex = 23;
-			this.label7.Text = " ";
-			// 
-			// label5
-			// 
-			this.label5.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-			this.label5.AutoSize = true;
-			this.label5.Location = new System.Drawing.Point(30, 415);
-			this.label5.Name = "label5";
-			this.label5.Size = new System.Drawing.Size(69, 13);
-			this.label5.TabIndex = 22;
-			this.label5.Text = "Inserted lines";
-			// 
-			// label4
-			// 
-			this.label4.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-			this.label4.BackColor = System.Drawing.Color.PaleGreen;
-			this.label4.Location = new System.Drawing.Point(12, 415);
-			this.label4.Name = "label4";
-			this.label4.Size = new System.Drawing.Size(12, 13);
-			this.label4.TabIndex = 21;
-			this.label4.Text = " ";
-			// 
-			// btCompare
-			// 
-			this.btCompare.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-			this.btCompare.Enabled = false;
-			this.btCompare.Location = new System.Drawing.Point(515, 410);
-			this.btCompare.Name = "btCompare";
-			this.btCompare.Size = new System.Drawing.Size(75, 23);
-			this.btCompare.TabIndex = 25;
-			this.btCompare.Text = "Compare";
-			this.btCompare.UseVisualStyleBackColor = true;
-			this.btCompare.Click += new System.EventHandler(this.btCompare_Click);
-			// 
-			// fctb1
-			// 
-			this.fctb1.AutoCompleteBracketsList = new char[] {
+            this.components = new System.ComponentModel.Container();
+            this.label6 = new System.Windows.Forms.Label();
+            this.label7 = new System.Windows.Forms.Label();
+            this.label5 = new System.Windows.Forms.Label();
+            this.label4 = new System.Windows.Forms.Label();
+            this.ofdFile = new System.Windows.Forms.OpenFileDialog();
+            this.btCompare = new System.Windows.Forms.Button();
+            this.fctb1 = new FastColoredTextBoxNS.FastColoredTextBox();
+            this.fctb2 = new FastColoredTextBoxNS.FastColoredTextBox();
+            this.splitContainer1 = new System.Windows.Forms.SplitContainer();
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.label1 = new System.Windows.Forms.Label();
+            this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
+            this.label2 = new System.Windows.Forms.Label();
+            this.bClose = new System.Windows.Forms.Button();
+            ((System.ComponentModel.ISupportInitialize)(this.fctb1)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.fctb2)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
+            this.splitContainer1.Panel1.SuspendLayout();
+            this.splitContainer1.Panel2.SuspendLayout();
+            this.splitContainer1.SuspendLayout();
+            this.tableLayoutPanel1.SuspendLayout();
+            this.tableLayoutPanel2.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // label6
+            // 
+            this.label6.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.label6.AutoSize = true;
+            this.label6.Location = new System.Drawing.Point(136, 415);
+            this.label6.Name = "label6";
+            this.label6.Size = new System.Drawing.Size(68, 13);
+            this.label6.TabIndex = 24;
+            this.label6.Text = "Deleted lines";
+            // 
+            // label7
+            // 
+            this.label7.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.label7.BackColor = System.Drawing.Color.Pink;
+            this.label7.Location = new System.Drawing.Point(118, 415);
+            this.label7.Name = "label7";
+            this.label7.Size = new System.Drawing.Size(12, 13);
+            this.label7.TabIndex = 23;
+            this.label7.Text = " ";
+            // 
+            // label5
+            // 
+            this.label5.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.label5.AutoSize = true;
+            this.label5.Location = new System.Drawing.Point(30, 415);
+            this.label5.Name = "label5";
+            this.label5.Size = new System.Drawing.Size(69, 13);
+            this.label5.TabIndex = 22;
+            this.label5.Text = "Inserted lines";
+            // 
+            // label4
+            // 
+            this.label4.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.label4.BackColor = System.Drawing.Color.PaleGreen;
+            this.label4.Location = new System.Drawing.Point(12, 415);
+            this.label4.Name = "label4";
+            this.label4.Size = new System.Drawing.Size(12, 13);
+            this.label4.TabIndex = 21;
+            this.label4.Text = " ";
+            // 
+            // btCompare
+            // 
+            this.btCompare.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btCompare.Enabled = false;
+            this.btCompare.Location = new System.Drawing.Point(566, 410);
+            this.btCompare.Name = "btCompare";
+            this.btCompare.Size = new System.Drawing.Size(75, 23);
+            this.btCompare.TabIndex = 25;
+            this.btCompare.Text = "C&ompare";
+            this.btCompare.UseVisualStyleBackColor = true;
+            this.btCompare.Click += new System.EventHandler(this.btCompare_Click);
+            // 
+            // fctb1
+            // 
+            this.fctb1.AutoCompleteBracketsList = new char[] {
         '(',
         ')',
         '{',
@@ -117,31 +118,31 @@
         '\"',
         '\'',
         '\''};
-			this.fctb1.AutoScrollMinSize = new System.Drawing.Size(179, 14);
-			this.fctb1.BackBrush = null;
-			this.fctb1.CharHeight = 14;
-			this.fctb1.CharWidth = 8;
-			this.fctb1.Cursor = System.Windows.Forms.Cursors.IBeam;
-			this.fctb1.DisabledColor = System.Drawing.Color.FromArgb(((int)(((byte)(100)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))));
-			this.fctb1.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.fctb1.IsReplaceMode = false;
-			this.fctb1.Location = new System.Drawing.Point(3, 23);
-			this.fctb1.Name = "fctb1";
-			this.fctb1.Paddings = new System.Windows.Forms.Padding(0);
-			this.fctb1.ReadOnly = true;
-			this.fctb1.SelectionColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(255)))));
-			this.fctb1.ServiceColors = null;
-			this.fctb1.Size = new System.Drawing.Size(349, 366);
-			this.fctb1.TabIndex = 26;
-			this.fctb1.Text = "fastColoredTextBox1";
-			this.fctb1.Zoom = 100;
-			this.fctb1.TextChanged += new System.EventHandler<FastColoredTextBoxNS.TextChangedEventArgs>(this.fctb_TextChanged);
-			this.fctb1.SelectionChanged += new System.EventHandler(this.tb_VisibleRangeChanged);
-			this.fctb1.VisibleRangeChanged += new System.EventHandler(this.tb_VisibleRangeChanged);
-			// 
-			// fctb2
-			// 
-			this.fctb2.AutoCompleteBracketsList = new char[] {
+            this.fctb1.AutoScrollMinSize = new System.Drawing.Size(179, 14);
+            this.fctb1.BackBrush = null;
+            this.fctb1.CharHeight = 14;
+            this.fctb1.CharWidth = 8;
+            this.fctb1.Cursor = System.Windows.Forms.Cursors.IBeam;
+            this.fctb1.DisabledColor = System.Drawing.Color.FromArgb(((int)(((byte)(100)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))));
+            this.fctb1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.fctb1.IsReplaceMode = false;
+            this.fctb1.Location = new System.Drawing.Point(3, 23);
+            this.fctb1.Name = "fctb1";
+            this.fctb1.Paddings = new System.Windows.Forms.Padding(0);
+            this.fctb1.ReadOnly = true;
+            this.fctb1.SelectionColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(255)))));
+            this.fctb1.ServiceColors = null;
+            this.fctb1.Size = new System.Drawing.Size(309, 366);
+            this.fctb1.TabIndex = 26;
+            this.fctb1.Text = "fastColoredTextBox1";
+            this.fctb1.Zoom = 100;
+            this.fctb1.TextChanged += new System.EventHandler<FastColoredTextBoxNS.TextChangedEventArgs>(this.fctb_TextChanged);
+            this.fctb1.SelectionChanged += new System.EventHandler(this.tb_VisibleRangeChanged);
+            this.fctb1.VisibleRangeChanged += new System.EventHandler(this.tb_VisibleRangeChanged);
+            // 
+            // fctb2
+            // 
+            this.fctb2.AutoCompleteBracketsList = new char[] {
         '(',
         ')',
         '{',
@@ -152,120 +153,133 @@
         '\"',
         '\'',
         '\''};
-			this.fctb2.AutoScrollMinSize = new System.Drawing.Size(179, 14);
-			this.fctb2.BackBrush = null;
-			this.fctb2.CharHeight = 14;
-			this.fctb2.CharWidth = 8;
-			this.fctb2.Cursor = System.Windows.Forms.Cursors.IBeam;
-			this.fctb2.DisabledColor = System.Drawing.Color.FromArgb(((int)(((byte)(100)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))));
-			this.fctb2.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.fctb2.IsReplaceMode = false;
-			this.fctb2.Location = new System.Drawing.Point(3, 23);
-			this.fctb2.Name = "fctb2";
-			this.fctb2.Paddings = new System.Windows.Forms.Padding(0);
-			this.fctb2.ReadOnly = true;
-			this.fctb2.SelectionColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(255)))));
-			this.fctb2.ServiceColors = null;
-			this.fctb2.Size = new System.Drawing.Size(345, 366);
-			this.fctb2.TabIndex = 27;
-			this.fctb2.Text = "fastColoredTextBox2";
-			this.fctb2.Zoom = 100;
-			this.fctb2.TextChanged += new System.EventHandler<FastColoredTextBoxNS.TextChangedEventArgs>(this.fctb_TextChanged);
-			this.fctb2.SelectionChanged += new System.EventHandler(this.tb_VisibleRangeChanged);
-			this.fctb2.VisibleRangeChanged += new System.EventHandler(this.tb_VisibleRangeChanged);
-			// 
-			// splitContainer1
-			// 
-			this.splitContainer1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            this.fctb2.AutoScrollMinSize = new System.Drawing.Size(179, 14);
+            this.fctb2.BackBrush = null;
+            this.fctb2.CharHeight = 14;
+            this.fctb2.CharWidth = 8;
+            this.fctb2.Cursor = System.Windows.Forms.Cursors.IBeam;
+            this.fctb2.DisabledColor = System.Drawing.Color.FromArgb(((int)(((byte)(100)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))));
+            this.fctb2.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.fctb2.IsReplaceMode = false;
+            this.fctb2.Location = new System.Drawing.Point(3, 23);
+            this.fctb2.Name = "fctb2";
+            this.fctb2.Paddings = new System.Windows.Forms.Padding(0);
+            this.fctb2.ReadOnly = true;
+            this.fctb2.SelectionColor = System.Drawing.Color.FromArgb(((int)(((byte)(60)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(255)))));
+            this.fctb2.ServiceColors = null;
+            this.fctb2.Size = new System.Drawing.Size(385, 366);
+            this.fctb2.TabIndex = 27;
+            this.fctb2.Text = "fastColoredTextBox2";
+            this.fctb2.Zoom = 100;
+            this.fctb2.TextChanged += new System.EventHandler<FastColoredTextBoxNS.TextChangedEventArgs>(this.fctb_TextChanged);
+            this.fctb2.SelectionChanged += new System.EventHandler(this.tb_VisibleRangeChanged);
+            this.fctb2.VisibleRangeChanged += new System.EventHandler(this.tb_VisibleRangeChanged);
+            // 
+            // splitContainer1
+            // 
+            this.splitContainer1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.splitContainer1.Location = new System.Drawing.Point(12, 12);
-			this.splitContainer1.Name = "splitContainer1";
-			// 
-			// splitContainer1.Panel1
-			// 
-			this.splitContainer1.Panel1.Controls.Add(this.tableLayoutPanel1);
-			// 
-			// splitContainer1.Panel2
-			// 
-			this.splitContainer1.Panel2.Controls.Add(this.tableLayoutPanel2);
-			this.splitContainer1.Size = new System.Drawing.Size(710, 392);
-			this.splitContainer1.SplitterDistance = 355;
-			this.splitContainer1.TabIndex = 28;
-			// 
-			// tableLayoutPanel1
-			// 
-			this.tableLayoutPanel1.ColumnCount = 1;
-			this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-			this.tableLayoutPanel1.Controls.Add(this.fctb1, 0, 1);
-			this.tableLayoutPanel1.Controls.Add(this.label1, 0, 0);
-			this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
-			this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-			this.tableLayoutPanel1.RowCount = 2;
-			this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-			this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-			this.tableLayoutPanel1.Size = new System.Drawing.Size(355, 392);
-			this.tableLayoutPanel1.TabIndex = 30;
-			// 
-			// label1
-			// 
-			this.label1.AutoSize = true;
-			this.label1.Location = new System.Drawing.Point(3, 0);
-			this.label1.Name = "label1";
-			this.label1.Size = new System.Drawing.Size(90, 13);
-			this.label1.TabIndex = 29;
-			this.label1.Text = "Saved Config File";
-			// 
-			// tableLayoutPanel2
-			// 
-			this.tableLayoutPanel2.ColumnCount = 1;
-			this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-			this.tableLayoutPanel2.Controls.Add(this.fctb2, 0, 1);
-			this.tableLayoutPanel2.Controls.Add(this.label2, 0, 0);
-			this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.tableLayoutPanel2.Location = new System.Drawing.Point(0, 0);
-			this.tableLayoutPanel2.Name = "tableLayoutPanel2";
-			this.tableLayoutPanel2.RowCount = 2;
-			this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-			this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-			this.tableLayoutPanel2.Size = new System.Drawing.Size(351, 392);
-			this.tableLayoutPanel2.TabIndex = 31;
-			// 
-			// label2
-			// 
-			this.label2.AutoSize = true;
-			this.label2.Location = new System.Drawing.Point(3, 0);
-			this.label2.Name = "label2";
-			this.label2.Size = new System.Drawing.Size(73, 13);
-			this.label2.TabIndex = 30;
-			this.label2.Text = "File From Disk";
-			// 
-			// ConfigDiff
-			// 
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.ClientSize = new System.Drawing.Size(734, 437);
-			this.Controls.Add(this.splitContainer1);
-			this.Controls.Add(this.btCompare);
-			this.Controls.Add(this.label6);
-			this.Controls.Add(this.label7);
-			this.Controls.Add(this.label5);
-			this.Controls.Add(this.label4);
-			this.Name = "ConfigDiff";
-			this.Text = "DiffMergeSample";
-			((System.ComponentModel.ISupportInitialize)(this.fctb1)).EndInit();
-			((System.ComponentModel.ISupportInitialize)(this.fctb2)).EndInit();
-			this.splitContainer1.Panel1.ResumeLayout(false);
-			this.splitContainer1.Panel2.ResumeLayout(false);
-			((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
-			this.splitContainer1.ResumeLayout(false);
-			this.tableLayoutPanel1.ResumeLayout(false);
-			this.tableLayoutPanel1.PerformLayout();
-			this.tableLayoutPanel2.ResumeLayout(false);
-			this.tableLayoutPanel2.PerformLayout();
-			this.ResumeLayout(false);
-			this.PerformLayout();
+            this.splitContainer1.Location = new System.Drawing.Point(12, 12);
+            this.splitContainer1.Name = "splitContainer1";
+            // 
+            // splitContainer1.Panel1
+            // 
+            this.splitContainer1.Panel1.Controls.Add(this.tableLayoutPanel1);
+            // 
+            // splitContainer1.Panel2
+            // 
+            this.splitContainer1.Panel2.Controls.Add(this.tableLayoutPanel2);
+            this.splitContainer1.Size = new System.Drawing.Size(710, 392);
+            this.splitContainer1.SplitterDistance = 315;
+            this.splitContainer1.TabIndex = 28;
+            // 
+            // tableLayoutPanel1
+            // 
+            this.tableLayoutPanel1.ColumnCount = 1;
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel1.Controls.Add(this.fctb1, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.label1, 0, 0);
+            this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            this.tableLayoutPanel1.RowCount = 2;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(315, 392);
+            this.tableLayoutPanel1.TabIndex = 30;
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(3, 0);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(90, 13);
+            this.label1.TabIndex = 29;
+            this.label1.Text = "Saved Config File";
+            // 
+            // tableLayoutPanel2
+            // 
+            this.tableLayoutPanel2.ColumnCount = 1;
+            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel2.Controls.Add(this.fctb2, 0, 1);
+            this.tableLayoutPanel2.Controls.Add(this.label2, 0, 0);
+            this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel2.Location = new System.Drawing.Point(0, 0);
+            this.tableLayoutPanel2.Name = "tableLayoutPanel2";
+            this.tableLayoutPanel2.RowCount = 2;
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel2.Size = new System.Drawing.Size(391, 392);
+            this.tableLayoutPanel2.TabIndex = 31;
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(3, 0);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(73, 13);
+            this.label2.TabIndex = 30;
+            this.label2.Text = "File From Disk";
+            // 
+            // bClose
+            // 
+            this.bClose.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.bClose.DialogResult = System.Windows.Forms.DialogResult.OK;
+            this.bClose.Enabled = false;
+            this.bClose.Location = new System.Drawing.Point(647, 410);
+            this.bClose.Name = "bClose";
+            this.bClose.Size = new System.Drawing.Size(75, 23);
+            this.bClose.TabIndex = 29;
+            this.bClose.Text = "&Close";
+            this.bClose.UseVisualStyleBackColor = true;
+            // 
+            // ConfigDiff
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(734, 437);
+            this.Controls.Add(this.bClose);
+            this.Controls.Add(this.splitContainer1);
+            this.Controls.Add(this.btCompare);
+            this.Controls.Add(this.label6);
+            this.Controls.Add(this.label7);
+            this.Controls.Add(this.label5);
+            this.Controls.Add(this.label4);
+            this.Name = "ConfigDiff";
+            this.Text = "DiffMergeSample";
+            ((System.ComponentModel.ISupportInitialize)(this.fctb1)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.fctb2)).EndInit();
+            this.splitContainer1.Panel1.ResumeLayout(false);
+            this.splitContainer1.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
+            this.splitContainer1.ResumeLayout(false);
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.tableLayoutPanel1.PerformLayout();
+            this.tableLayoutPanel2.ResumeLayout(false);
+            this.tableLayoutPanel2.PerformLayout();
+            this.ResumeLayout(false);
+            this.PerformLayout();
 
 		}
 
@@ -284,5 +298,6 @@
 		private System.Windows.Forms.Label label2;
 		private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
 		private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
-	}
+        private System.Windows.Forms.Button bClose;
+    }
 }

--- a/xcom2-launcher/xcom2-launcher/Forms/ConfigDiff.cs
+++ b/xcom2-launcher/xcom2-launcher/Forms/ConfigDiff.cs
@@ -35,6 +35,7 @@ namespace XCOM2Launcher.Forms
 		public ConfigDiff()
 		{
 			InitializeComponent();
+			CancelButton = bClose;
 		}
 
 		public void CompareStrings(string s1, string s2)
@@ -144,11 +145,11 @@ namespace XCOM2Launcher.Forms
 		{
 			IniLanguage.Process(e);
 		}
-	}
+    }
 
-	#region Merge stuffs
+    #region Merge stuffs
 
-	namespace DiffMergeStuffs
+    namespace DiffMergeStuffs
 	{
 		public class SimpleDiff<T>
 		{

--- a/xcom2-launcher/xcom2-launcher/Forms/MainForm.Events.cs
+++ b/xcom2-launcher/xcom2-launcher/Forms/MainForm.Events.cs
@@ -199,7 +199,7 @@ namespace XCOM2Launcher.Forms
             editOptionsToolStripMenuItem.Click += delegate
             {
                 Log.Info("Menu->Options->Settings");
-                var dialog = new SettingsDialog(Settings);
+                using var dialog = new SettingsDialog(Settings);
 
                 if (dialog.ShowDialog() == DialogResult.OK)
                 {
@@ -234,7 +234,11 @@ namespace XCOM2Launcher.Forms
             #region Menu->Tools
 
             // -> Tools
-            cleanModsToolStripMenuItem.Click += delegate { new CleanModsForm(Settings).ShowDialog(); };
+            cleanModsToolStripMenuItem.Click += delegate
+            {
+                using var dlg = new CleanModsForm(Settings);
+                dlg.ShowDialog();
+            };
 
             importFromXCOM2ToolStripMenuItem.Click += delegate
             {
@@ -289,7 +293,7 @@ namespace XCOM2Launcher.Forms
             infoToolStripMenuItem.Click += delegate
             {
                 Log.Info("Menu->About->About");
-                AboutBox about = new AboutBox();
+                using var about = new AboutBox();
                 about.ShowDialog();
             };
 
@@ -356,7 +360,7 @@ namespace XCOM2Launcher.Forms
         {
             Log.Info("Menu->Options->Categories");
 
-            CategoryManager catManager = new CategoryManager(Settings);
+            using var catManager = new CategoryManager(Settings);
             var result = catManager.ShowDialog();
 
             if (result == DialogResult.OK)
@@ -459,7 +463,7 @@ namespace XCOM2Launcher.Forms
 
         private void ExportLoadButtonClick(object sender, EventArgs e)
         {
-            var dialog = new OpenFileDialog
+            using var dialog = new OpenFileDialog
             {
                 Filter = "Text files|*.txt",
                 DefaultExt = "txt",
@@ -608,7 +612,7 @@ namespace XCOM2Launcher.Forms
 
         private void ExportSaveButtonClick(object sender, EventArgs eventArgs)
         {
-            var dialog = new SaveFileDialog
+            using var dialog = new SaveFileDialog
             {
                 Filter = "Text files|*.txt",
                 DefaultExt = "txt",

--- a/xcom2-launcher/xcom2-launcher/Forms/MainForm.ModList.cs
+++ b/xcom2-launcher/xcom2-launcher/Forms/MainForm.ModList.cs
@@ -727,7 +727,7 @@ namespace XCOM2Launcher.Forms
 
             editColor.Click += (sender, e) =>
             {
-                var colorPicker = new ColorDialog
+                using var colorPicker = new ColorDialog
                 {
                     AllowFullOpen = true,
                     Color = tag.Color,

--- a/xcom2-launcher/xcom2-launcher/Forms/MainForm.cs
+++ b/xcom2-launcher/xcom2-launcher/Forms/MainForm.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Linq;
@@ -13,7 +12,6 @@ using XCOM2Launcher.Mod;
 using XCOM2Launcher.XCOM;
 using JR.Utils.GUI.Forms;
 using XCOM2Launcher.Classes.Mod;
-using XCOM2Launcher.Steam;
 
 namespace XCOM2Launcher.Forms
 {

--- a/xcom2-launcher/xcom2-launcher/Forms/SettingsDialog.Designer.cs
+++ b/xcom2-launcher/xcom2-launcher/Forms/SettingsDialog.Designer.cs
@@ -28,564 +28,583 @@
         /// </summary>
         private void InitializeComponent()
         {
-	        this.components = new System.ComponentModel.Container();
-	        System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(SettingsDialog));
-	        this.groupBox1 = new System.Windows.Forms.GroupBox();
-	        this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
-	        this.quickArgumentsTextBox = new XCOM2Launcher.UserElements.AutoCompleteTextBox();
-	        this.label2 = new System.Windows.Forms.Label();
-	        this.label1 = new System.Windows.Forms.Label();
-	        this.modPathsListbox = new System.Windows.Forms.ListBox();
-	        this.ShowQuickLaunchArgumentsToggle = new System.Windows.Forms.CheckBox();
-	        this.label3 = new System.Windows.Forms.Label();
-	        this.label4 = new System.Windows.Forms.Label();
-	        this.gamePathTextBox = new System.Windows.Forms.TextBox();
-	        this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
-	        this.addModPathButton = new System.Windows.Forms.Button();
-	        this.removeModPathButton = new System.Windows.Forms.Button();
-	        this.browseGamePathButton = new System.Windows.Forms.Button();
-	        this.argumentsTextBox = new XCOM2Launcher.UserElements.AutoCompleteTextBox();
-	        this.groupBox2 = new System.Windows.Forms.GroupBox();
-	        this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
-	        this.updateModsOnStartup = new System.Windows.Forms.CheckBox();
-	        this.useModSpecifiedCategoriesCheckBox = new System.Windows.Forms.CheckBox();
-	        this.autoNumberModIndexesCheckBox = new System.Windows.Forms.CheckBox();
-	        this.neverAdoptTagsAndCatFromprofile = new System.Windows.Forms.CheckBox();
-	        this.useDuplicateModWorkaround = new System.Windows.Forms.CheckBox();
-	        this.onlyUpdateEnabledAndNew = new System.Windows.Forms.CheckBox();
-	        this.showHiddenEntriesCheckBox = new System.Windows.Forms.CheckBox();
-	        this.useTranslucentModListSelection = new System.Windows.Forms.CheckBox();
-	        this.useSentry = new System.Windows.Forms.CheckBox();
-	        this.closeAfterLaunchCheckBox = new System.Windows.Forms.CheckBox();
-	        this.searchForUpdatesCheckBox = new System.Windows.Forms.CheckBox();
-	        this.checkForPreReleaseUpdates = new System.Windows.Forms.CheckBox();
-	        this.toolTip = new System.Windows.Forms.ToolTip(this.components);
-	        this.allowMutipleInstances = new System.Windows.Forms.CheckBox();
-	        this.bOK = new System.Windows.Forms.Button();
-	        this.bCancel = new System.Windows.Forms.Button();
-	        this.groupBox3 = new System.Windows.Forms.GroupBox();
-	        this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-	        this.groupBox4 = new System.Windows.Forms.GroupBox();
-	        this.tableLayoutPanel4 = new System.Windows.Forms.TableLayoutPanel();
-	        this.hideRunX2Button = new System.Windows.Forms.CheckBox();
-	        this.hideChallengeModeButton = new System.Windows.Forms.CheckBox();
-	        this.groupBox1.SuspendLayout();
-	        this.tableLayoutPanel2.SuspendLayout();
-	        this.flowLayoutPanel1.SuspendLayout();
-	        this.groupBox2.SuspendLayout();
-	        this.tableLayoutPanel3.SuspendLayout();
-	        this.groupBox3.SuspendLayout();
-	        this.tableLayoutPanel1.SuspendLayout();
-	        this.groupBox4.SuspendLayout();
-	        this.tableLayoutPanel4.SuspendLayout();
-	        this.SuspendLayout();
-	        // 
-	        // groupBox1
-	        // 
-	        this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
-	        this.groupBox1.Controls.Add(this.tableLayoutPanel2);
-	        this.groupBox1.Location = new System.Drawing.Point(12, 8);
-	        this.groupBox1.Name = "groupBox1";
-	        this.groupBox1.Size = new System.Drawing.Size(655, 200);
-	        this.groupBox1.TabIndex = 9;
-	        this.groupBox1.TabStop = false;
-	        this.groupBox1.Text = "Game options";
-	        // 
-	        // tableLayoutPanel2
-	        // 
-	        this.tableLayoutPanel2.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
-	        this.tableLayoutPanel2.ColumnCount = 3;
-	        this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 130F));
-	        this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-	        this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-	        this.tableLayoutPanel2.Controls.Add(this.quickArgumentsTextBox, 1, 3);
-	        this.tableLayoutPanel2.Controls.Add(this.label2, 0, 3);
-	        this.tableLayoutPanel2.Controls.Add(this.label1, 0, 2);
-	        this.tableLayoutPanel2.Controls.Add(this.modPathsListbox, 1, 1);
-	        this.tableLayoutPanel2.Controls.Add(this.ShowQuickLaunchArgumentsToggle, 2, 3);
-	        this.tableLayoutPanel2.Controls.Add(this.label3, 0, 0);
-	        this.tableLayoutPanel2.Controls.Add(this.label4, 0, 1);
-	        this.tableLayoutPanel2.Controls.Add(this.gamePathTextBox, 1, 0);
-	        this.tableLayoutPanel2.Controls.Add(this.flowLayoutPanel1, 2, 1);
-	        this.tableLayoutPanel2.Controls.Add(this.browseGamePathButton, 2, 0);
-	        this.tableLayoutPanel2.Controls.Add(this.argumentsTextBox, 1, 2);
-	        this.tableLayoutPanel2.Location = new System.Drawing.Point(3, 19);
-	        this.tableLayoutPanel2.Name = "tableLayoutPanel2";
-	        this.tableLayoutPanel2.RowCount = 4;
-	        this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
-	        this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-	        this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 25F));
-	        this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 25F));
-	        this.tableLayoutPanel2.Size = new System.Drawing.Size(641, 175);
-	        this.tableLayoutPanel2.TabIndex = 6;
-	        // 
-	        // quickArgumentsTextBox
-	        // 
-	        this.quickArgumentsTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
-	        this.quickArgumentsTextBox.Location = new System.Drawing.Point(133, 153);
-	        this.quickArgumentsTextBox.Name = "quickArgumentsTextBox";
-	        this.quickArgumentsTextBox.Size = new System.Drawing.Size(432, 20);
-	        this.quickArgumentsTextBox.TabIndex = 16;
-	        this.quickArgumentsTextBox.Values = new string[0];
-	        // 
-	        // label2
-	        // 
-	        this.label2.AutoSize = true;
-	        this.label2.Location = new System.Drawing.Point(4, 156);
-	        this.label2.Margin = new System.Windows.Forms.Padding(4, 6, 3, 0);
-	        this.label2.Name = "label2";
-	        this.label2.Size = new System.Drawing.Size(119, 13);
-	        this.label2.TabIndex = 14;
-	        this.label2.Text = "Quick toggle arguments";
-	        // 
-	        // label1
-	        // 
-	        this.label1.AutoSize = true;
-	        this.label1.Location = new System.Drawing.Point(4, 131);
-	        this.label1.Margin = new System.Windows.Forms.Padding(4, 6, 3, 0);
-	        this.label1.Name = "label1";
-	        this.label1.Size = new System.Drawing.Size(89, 13);
-	        this.label1.TabIndex = 0;
-	        this.label1.Text = "Active arguments";
-	        // 
-	        // modPathsListbox
-	        // 
-	        this.modPathsListbox.Dock = System.Windows.Forms.DockStyle.Fill;
-	        this.modPathsListbox.FormattingEnabled = true;
-	        this.modPathsListbox.Location = new System.Drawing.Point(133, 33);
-	        this.modPathsListbox.Name = "modPathsListbox";
-	        this.modPathsListbox.Size = new System.Drawing.Size(432, 89);
-	        this.modPathsListbox.TabIndex = 4;
-	        // 
-	        // ShowQuickLaunchArgumentsToggle
-	        // 
-	        this.ShowQuickLaunchArgumentsToggle.AutoSize = true;
-	        this.ShowQuickLaunchArgumentsToggle.Location = new System.Drawing.Point(571, 153);
-	        this.ShowQuickLaunchArgumentsToggle.Name = "ShowQuickLaunchArgumentsToggle";
-	        this.ShowQuickLaunchArgumentsToggle.Padding = new System.Windows.Forms.Padding(3, 3, 0, 0);
-	        this.ShowQuickLaunchArgumentsToggle.Size = new System.Drawing.Size(62, 19);
-	        this.ShowQuickLaunchArgumentsToggle.TabIndex = 17;
-	        this.ShowQuickLaunchArgumentsToggle.Text = "Enable";
-	        this.toolTip.SetToolTip(this.ShowQuickLaunchArgumentsToggle, "If enabled, a combo-box that allows to quickly toggle the\r\nspecified quick toggle" + " arguments is displayed on the main screen.");
-	        this.ShowQuickLaunchArgumentsToggle.UseVisualStyleBackColor = true;
-	        // 
-	        // label3
-	        // 
-	        this.label3.AutoSize = true;
-	        this.label3.Location = new System.Drawing.Point(4, 6);
-	        this.label3.Margin = new System.Windows.Forms.Padding(4, 6, 3, 0);
-	        this.label3.Name = "label3";
-	        this.label3.Size = new System.Drawing.Size(56, 13);
-	        this.label3.TabIndex = 0;
-	        this.label3.Text = "Base Path";
-	        // 
-	        // label4
-	        // 
-	        this.label4.AutoSize = true;
-	        this.label4.Location = new System.Drawing.Point(4, 36);
-	        this.label4.Margin = new System.Windows.Forms.Padding(4, 6, 3, 0);
-	        this.label4.Name = "label4";
-	        this.label4.Size = new System.Drawing.Size(81, 13);
-	        this.label4.TabIndex = 2;
-	        this.label4.Text = "Mod Directories";
-	        // 
-	        // gamePathTextBox
-	        // 
-	        this.gamePathTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
-	        this.gamePathTextBox.Location = new System.Drawing.Point(133, 3);
-	        this.gamePathTextBox.Name = "gamePathTextBox";
-	        this.gamePathTextBox.Size = new System.Drawing.Size(432, 20);
-	        this.gamePathTextBox.TabIndex = 10;
-	        // 
-	        // flowLayoutPanel1
-	        // 
-	        this.flowLayoutPanel1.Controls.Add(this.addModPathButton);
-	        this.flowLayoutPanel1.Controls.Add(this.removeModPathButton);
-	        this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-	        this.flowLayoutPanel1.Location = new System.Drawing.Point(568, 30);
-	        this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(0);
-	        this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-	        this.flowLayoutPanel1.Size = new System.Drawing.Size(73, 95);
-	        this.flowLayoutPanel1.TabIndex = 12;
-	        // 
-	        // addModPathButton
-	        // 
-	        this.addModPathButton.Location = new System.Drawing.Point(3, 3);
-	        this.addModPathButton.Name = "addModPathButton";
-	        this.addModPathButton.Size = new System.Drawing.Size(67, 24);
-	        this.addModPathButton.TabIndex = 6;
-	        this.addModPathButton.Text = "Add";
-	        this.addModPathButton.UseVisualStyleBackColor = true;
-	        this.addModPathButton.Click += new System.EventHandler(this.AddModPathButtonOnClick);
-	        // 
-	        // removeModPathButton
-	        // 
-	        this.removeModPathButton.Location = new System.Drawing.Point(3, 33);
-	        this.removeModPathButton.Name = "removeModPathButton";
-	        this.removeModPathButton.Size = new System.Drawing.Size(67, 24);
-	        this.removeModPathButton.TabIndex = 8;
-	        this.removeModPathButton.Text = "Remove";
-	        this.removeModPathButton.UseVisualStyleBackColor = true;
-	        this.removeModPathButton.Click += new System.EventHandler(this.RemoveModPathButtonOnClick);
-	        // 
-	        // browseGamePathButton
-	        // 
-	        this.browseGamePathButton.Location = new System.Drawing.Point(571, 3);
-	        this.browseGamePathButton.Name = "browseGamePathButton";
-	        this.browseGamePathButton.Size = new System.Drawing.Size(67, 24);
-	        this.browseGamePathButton.TabIndex = 14;
-	        this.browseGamePathButton.Text = "Browse";
-	        this.browseGamePathButton.UseVisualStyleBackColor = true;
-	        this.browseGamePathButton.Click += new System.EventHandler(this.BrowseGamePathButtonOnClick);
-	        // 
-	        // argumentsTextBox
-	        // 
-	        this.argumentsTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
-	        this.argumentsTextBox.Location = new System.Drawing.Point(133, 128);
-	        this.argumentsTextBox.Name = "argumentsTextBox";
-	        this.argumentsTextBox.Size = new System.Drawing.Size(432, 20);
-	        this.argumentsTextBox.TabIndex = 15;
-	        this.argumentsTextBox.Values = new string[0];
-	        // 
-	        // groupBox2
-	        // 
-	        this.groupBox2.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
-	        this.groupBox2.Controls.Add(this.tableLayoutPanel3);
-	        this.groupBox2.Location = new System.Drawing.Point(12, 297);
-	        this.groupBox2.Name = "groupBox2";
-	        this.groupBox2.Size = new System.Drawing.Size(655, 82);
-	        this.groupBox2.TabIndex = 10;
-	        this.groupBox2.TabStop = false;
-	        this.groupBox2.Text = "Usability";
-	        // 
-	        // tableLayoutPanel3
-	        // 
-	        this.tableLayoutPanel3.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
-	        this.tableLayoutPanel3.ColumnCount = 3;
-	        this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 33.33333F));
-	        this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 33.33334F));
-	        this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 33.33334F));
-	        this.tableLayoutPanel3.Controls.Add(this.updateModsOnStartup, 0, 1);
-	        this.tableLayoutPanel3.Controls.Add(this.useModSpecifiedCategoriesCheckBox, 0, 1);
-	        this.tableLayoutPanel3.Controls.Add(this.autoNumberModIndexesCheckBox, 0, 0);
-	        this.tableLayoutPanel3.Controls.Add(this.neverAdoptTagsAndCatFromprofile, 1, 0);
-	        this.tableLayoutPanel3.Controls.Add(this.useDuplicateModWorkaround, 2, 0);
-	        this.tableLayoutPanel3.Controls.Add(this.onlyUpdateEnabledAndNew, 2, 1);
-	        this.tableLayoutPanel3.Location = new System.Drawing.Point(3, 20);
-	        this.tableLayoutPanel3.Name = "tableLayoutPanel3";
-	        this.tableLayoutPanel3.RowCount = 2;
-	        this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
-	        this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
-	        this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-	        this.tableLayoutPanel3.Size = new System.Drawing.Size(641, 56);
-	        this.tableLayoutPanel3.TabIndex = 6;
-	        // 
-	        // updateModsOnStartup
-	        // 
-	        this.updateModsOnStartup.AutoSize = true;
-	        this.updateModsOnStartup.Location = new System.Drawing.Point(216, 29);
-	        this.updateModsOnStartup.Name = "updateModsOnStartup";
-	        this.updateModsOnStartup.Padding = new System.Windows.Forms.Padding(3, 3, 0, 0);
-	        this.updateModsOnStartup.Size = new System.Drawing.Size(142, 20);
-	        this.updateModsOnStartup.TabIndex = 18;
-	        this.updateModsOnStartup.Text = "Update mods on startup";
-	        this.toolTip.SetToolTip(this.updateModsOnStartup, resources.GetString("updateModsOnStartup.ToolTip"));
-	        this.updateModsOnStartup.UseVisualStyleBackColor = true;
-	        this.updateModsOnStartup.CheckedChanged += new System.EventHandler(this.updateModsOnStartup_CheckedChanged);
-	        // 
-	        // useModSpecifiedCategoriesCheckBox
-	        // 
-	        this.useModSpecifiedCategoriesCheckBox.AutoSize = true;
-	        this.useModSpecifiedCategoriesCheckBox.Location = new System.Drawing.Point(3, 29);
-	        this.useModSpecifiedCategoriesCheckBox.Name = "useModSpecifiedCategoriesCheckBox";
-	        this.useModSpecifiedCategoriesCheckBox.Padding = new System.Windows.Forms.Padding(3, 3, 0, 0);
-	        this.useModSpecifiedCategoriesCheckBox.Size = new System.Drawing.Size(168, 20);
-	        this.useModSpecifiedCategoriesCheckBox.TabIndex = 15;
-	        this.useModSpecifiedCategoriesCheckBox.Text = "Use mod-specified categories";
-	        this.toolTip.SetToolTip(this.useModSpecifiedCategoriesCheckBox, "Toggle whether new mods appear in their specified \r\ndefault category (turn off to" + " have all mods appear in Unsorted).");
-	        this.useModSpecifiedCategoriesCheckBox.UseVisualStyleBackColor = true;
-	        // 
-	        // autoNumberModIndexesCheckBox
-	        // 
-	        this.autoNumberModIndexesCheckBox.AutoSize = true;
-	        this.autoNumberModIndexesCheckBox.Location = new System.Drawing.Point(3, 3);
-	        this.autoNumberModIndexesCheckBox.Name = "autoNumberModIndexesCheckBox";
-	        this.autoNumberModIndexesCheckBox.Padding = new System.Windows.Forms.Padding(3, 3, 0, 0);
-	        this.autoNumberModIndexesCheckBox.Size = new System.Drawing.Size(151, 20);
-	        this.autoNumberModIndexesCheckBox.TabIndex = 14;
-	        this.autoNumberModIndexesCheckBox.Text = "Auto-number mod indexes";
-	        this.toolTip.SetToolTip(this.autoNumberModIndexesCheckBox, "Auto-number mod indexes, when \r\none is changed (turn off to edit manually).");
-	        this.autoNumberModIndexesCheckBox.UseVisualStyleBackColor = true;
-	        // 
-	        // neverAdoptTagsAndCatFromprofile
-	        // 
-	        this.neverAdoptTagsAndCatFromprofile.AutoSize = true;
-	        this.neverAdoptTagsAndCatFromprofile.Location = new System.Drawing.Point(216, 3);
-	        this.neverAdoptTagsAndCatFromprofile.Name = "neverAdoptTagsAndCatFromprofile";
-	        this.neverAdoptTagsAndCatFromprofile.Padding = new System.Windows.Forms.Padding(3, 3, 0, 0);
-	        this.neverAdoptTagsAndCatFromprofile.Size = new System.Drawing.Size(185, 20);
-	        this.neverAdoptTagsAndCatFromprofile.TabIndex = 16;
-	        this.neverAdoptTagsAndCatFromprofile.Text = "Never import tags and categories";
-	        this.toolTip.SetToolTip(this.neverAdoptTagsAndCatFromprofile, "If enabled, currently assigned tags and categories\r\nwill always be preserved when" + " importing profiles.");
-	        this.neverAdoptTagsAndCatFromprofile.UseVisualStyleBackColor = true;
-	        // 
-	        // useDuplicateModWorkaround
-	        // 
-	        this.useDuplicateModWorkaround.AutoSize = true;
-	        this.useDuplicateModWorkaround.Location = new System.Drawing.Point(429, 3);
-	        this.useDuplicateModWorkaround.Name = "useDuplicateModWorkaround";
-	        this.useDuplicateModWorkaround.Padding = new System.Windows.Forms.Padding(3, 3, 0, 0);
-	        this.useDuplicateModWorkaround.Size = new System.Drawing.Size(204, 20);
-	        this.useDuplicateModWorkaround.TabIndex = 17;
-	        this.useDuplicateModWorkaround.Text = "Enable duplicate mod ID workaround";
-	        this.toolTip.SetToolTip(this.useDuplicateModWorkaround, resources.GetString("useDuplicateModWorkaround.ToolTip"));
-	        this.useDuplicateModWorkaround.UseVisualStyleBackColor = true;
-	        // 
-	        // onlyUpdateEnabledAndNew
-	        // 
-	        this.onlyUpdateEnabledAndNew.AutoSize = true;
-	        this.onlyUpdateEnabledAndNew.Location = new System.Drawing.Point(429, 29);
-	        this.onlyUpdateEnabledAndNew.Name = "onlyUpdateEnabledAndNew";
-	        this.onlyUpdateEnabledAndNew.Padding = new System.Windows.Forms.Padding(3, 3, 0, 0);
-	        this.onlyUpdateEnabledAndNew.Size = new System.Drawing.Size(190, 20);
-	        this.onlyUpdateEnabledAndNew.TabIndex = 19;
-	        this.onlyUpdateEnabledAndNew.Text = "Only update enabled or new mods";
-	        this.toolTip.SetToolTip(this.onlyUpdateEnabledAndNew, resources.GetString("onlyUpdateEnabledAndNew.ToolTip"));
-	        this.onlyUpdateEnabledAndNew.UseVisualStyleBackColor = true;
-	        // 
-	        // showHiddenEntriesCheckBox
-	        // 
-	        this.showHiddenEntriesCheckBox.AutoSize = true;
-	        this.showHiddenEntriesCheckBox.Location = new System.Drawing.Point(216, 3);
-	        this.showHiddenEntriesCheckBox.Name = "showHiddenEntriesCheckBox";
-	        this.showHiddenEntriesCheckBox.Padding = new System.Windows.Forms.Padding(3, 3, 0, 0);
-	        this.showHiddenEntriesCheckBox.Size = new System.Drawing.Size(119, 20);
-	        this.showHiddenEntriesCheckBox.TabIndex = 9;
-	        this.showHiddenEntriesCheckBox.Text = "Show hidden mods";
-	        this.toolTip.SetToolTip(this.showHiddenEntriesCheckBox, "If enabled, hidden mod entries will \r\nbe shown in the mod list.");
-	        this.showHiddenEntriesCheckBox.UseVisualStyleBackColor = true;
-	        // 
-	        // useTranslucentModListSelection
-	        // 
-	        this.useTranslucentModListSelection.AutoSize = true;
-	        this.useTranslucentModListSelection.Location = new System.Drawing.Point(3, 3);
-	        this.useTranslucentModListSelection.Name = "useTranslucentModListSelection";
-	        this.useTranslucentModListSelection.Padding = new System.Windows.Forms.Padding(3, 3, 0, 0);
-	        this.useTranslucentModListSelection.Size = new System.Drawing.Size(183, 20);
-	        this.useTranslucentModListSelection.TabIndex = 14;
-	        this.useTranslucentModListSelection.Text = "Use translucent modlist selection";
-	        this.toolTip.SetToolTip(this.useTranslucentModListSelection, "If enabled, selected items in the mod lists will be highlighted with a\r\ntransluce" + "nt selection color instead of the default opaque blue.");
-	        this.useTranslucentModListSelection.UseVisualStyleBackColor = true;
-	        // 
-	        // useSentry
-	        // 
-	        this.useSentry.AutoSize = true;
-	        this.useSentry.Location = new System.Drawing.Point(429, 3);
-	        this.useSentry.Name = "useSentry";
-	        this.useSentry.Padding = new System.Windows.Forms.Padding(3, 3, 0, 0);
-	        this.useSentry.Size = new System.Drawing.Size(170, 20);
-	        this.useSentry.TabIndex = 17;
-	        this.useSentry.Text = "Send anonymous error reports";
-	        this.toolTip.SetToolTip(this.useSentry, "If enabled, critical errors or other \r\npotential issues are automatically reporte" + "d to\r\nour X2CommunityCore Sentry.io account.");
-	        this.useSentry.UseVisualStyleBackColor = true;
-	        // 
-	        // closeAfterLaunchCheckBox
-	        // 
-	        this.closeAfterLaunchCheckBox.AutoSize = true;
-	        this.closeAfterLaunchCheckBox.Location = new System.Drawing.Point(216, 29);
-	        this.closeAfterLaunchCheckBox.Name = "closeAfterLaunchCheckBox";
-	        this.closeAfterLaunchCheckBox.Padding = new System.Windows.Forms.Padding(3, 3, 0, 0);
-	        this.closeAfterLaunchCheckBox.Size = new System.Drawing.Size(114, 20);
-	        this.closeAfterLaunchCheckBox.TabIndex = 7;
-	        this.closeAfterLaunchCheckBox.Text = "Close after launch";
-	        this.toolTip.SetToolTip(this.closeAfterLaunchCheckBox, "Close the launcher after launching the game.");
-	        this.closeAfterLaunchCheckBox.UseVisualStyleBackColor = true;
-	        // 
-	        // searchForUpdatesCheckBox
-	        // 
-	        this.searchForUpdatesCheckBox.AutoSize = true;
-	        this.searchForUpdatesCheckBox.Location = new System.Drawing.Point(3, 3);
-	        this.searchForUpdatesCheckBox.Name = "searchForUpdatesCheckBox";
-	        this.searchForUpdatesCheckBox.Padding = new System.Windows.Forms.Padding(3, 3, 0, 0);
-	        this.searchForUpdatesCheckBox.Size = new System.Drawing.Size(116, 20);
-	        this.searchForUpdatesCheckBox.TabIndex = 10;
-	        this.searchForUpdatesCheckBox.Text = "Check for updates";
-	        this.toolTip.SetToolTip(this.searchForUpdatesCheckBox, "Check if a new Version is available on startup.");
-	        this.searchForUpdatesCheckBox.UseVisualStyleBackColor = true;
-	        this.searchForUpdatesCheckBox.CheckedChanged += new System.EventHandler(this.searchForUpdatesCheckBox_CheckedChanged);
-	        // 
-	        // checkForPreReleaseUpdates
-	        // 
-	        this.checkForPreReleaseUpdates.AutoSize = true;
-	        this.checkForPreReleaseUpdates.Location = new System.Drawing.Point(216, 3);
-	        this.checkForPreReleaseUpdates.Name = "checkForPreReleaseUpdates";
-	        this.checkForPreReleaseUpdates.Padding = new System.Windows.Forms.Padding(3, 3, 0, 0);
-	        this.checkForPreReleaseUpdates.Size = new System.Drawing.Size(166, 20);
-	        this.checkForPreReleaseUpdates.TabIndex = 18;
-	        this.checkForPreReleaseUpdates.Text = "Include Pre-Release updates";
-	        this.toolTip.SetToolTip(this.checkForPreReleaseUpdates, "Enabled this option, if you wold like to be notified about Pre-Release versions.");
-	        this.checkForPreReleaseUpdates.UseVisualStyleBackColor = true;
-	        // 
-	        // toolTip
-	        // 
-	        this.toolTip.AutoPopDelay = 10000;
-	        this.toolTip.InitialDelay = 300;
-	        this.toolTip.IsBalloon = true;
-	        this.toolTip.ReshowDelay = 100;
-	        // 
-	        // allowMutipleInstances
-	        // 
-	        this.allowMutipleInstances.AutoSize = true;
-	        this.allowMutipleInstances.Location = new System.Drawing.Point(3, 29);
-	        this.allowMutipleInstances.Name = "allowMutipleInstances";
-	        this.allowMutipleInstances.Padding = new System.Windows.Forms.Padding(3, 3, 0, 0);
-	        this.allowMutipleInstances.Size = new System.Drawing.Size(140, 20);
-	        this.allowMutipleInstances.TabIndex = 19;
-	        this.allowMutipleInstances.Text = "Allow multiple instances";
-	        this.toolTip.SetToolTip(this.allowMutipleInstances, "If enabled, multiple instances of AML can be run in parallel.");
-	        this.allowMutipleInstances.UseVisualStyleBackColor = true;
-	        // 
-	        // bOK
-	        // 
-	        this.bOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-	        this.bOK.Location = new System.Drawing.Point(453, 502);
-	        this.bOK.Name = "bOK";
-	        this.bOK.Size = new System.Drawing.Size(104, 24);
-	        this.bOK.TabIndex = 12;
-	        this.bOK.Text = "OK";
-	        this.bOK.UseVisualStyleBackColor = true;
-	        this.bOK.Click += new System.EventHandler(this.bOK_Click);
-	        // 
-	        // bCancel
-	        // 
-	        this.bCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-	        this.bCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-	        this.bCancel.Location = new System.Drawing.Point(563, 502);
-	        this.bCancel.Name = "bCancel";
-	        this.bCancel.Size = new System.Drawing.Size(104, 24);
-	        this.bCancel.TabIndex = 11;
-	        this.bCancel.Text = "Cancel";
-	        this.bCancel.UseVisualStyleBackColor = true;
-	        // 
-	        // groupBox3
-	        // 
-	        this.groupBox3.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
-	        this.groupBox3.Controls.Add(this.tableLayoutPanel1);
-	        this.groupBox3.Location = new System.Drawing.Point(12, 214);
-	        this.groupBox3.Name = "groupBox3";
-	        this.groupBox3.Size = new System.Drawing.Size(655, 77);
-	        this.groupBox3.TabIndex = 13;
-	        this.groupBox3.TabStop = false;
-	        this.groupBox3.Text = "Application";
-	        // 
-	        // tableLayoutPanel1
-	        // 
-	        this.tableLayoutPanel1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
-	        this.tableLayoutPanel1.ColumnCount = 3;
-	        this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 33.33333F));
-	        this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 33.33334F));
-	        this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 33.33334F));
-	        this.tableLayoutPanel1.Controls.Add(this.searchForUpdatesCheckBox, 0, 0);
-	        this.tableLayoutPanel1.Controls.Add(this.checkForPreReleaseUpdates, 1, 0);
-	        this.tableLayoutPanel1.Controls.Add(this.useSentry, 2, 0);
-	        this.tableLayoutPanel1.Controls.Add(this.allowMutipleInstances, 0, 1);
-	        this.tableLayoutPanel1.Controls.Add(this.closeAfterLaunchCheckBox, 1, 1);
-	        this.tableLayoutPanel1.Location = new System.Drawing.Point(3, 19);
-	        this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-	        this.tableLayoutPanel1.RowCount = 2;
-	        this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
-	        this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
-	        this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-	        this.tableLayoutPanel1.Size = new System.Drawing.Size(641, 52);
-	        this.tableLayoutPanel1.TabIndex = 0;
-	        // 
-	        // groupBox4
-	        // 
-	        this.groupBox4.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
-	        this.groupBox4.Controls.Add(this.tableLayoutPanel4);
-	        this.groupBox4.Location = new System.Drawing.Point(12, 385);
-	        this.groupBox4.Name = "groupBox4";
-	        this.groupBox4.Size = new System.Drawing.Size(655, 111);
-	        this.groupBox4.TabIndex = 11;
-	        this.groupBox4.TabStop = false;
-	        this.groupBox4.Text = "User interface";
-	        // 
-	        // tableLayoutPanel4
-	        // 
-	        this.tableLayoutPanel4.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
-	        this.tableLayoutPanel4.ColumnCount = 3;
-	        this.tableLayoutPanel4.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 33.33333F));
-	        this.tableLayoutPanel4.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 33.33334F));
-	        this.tableLayoutPanel4.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 33.33334F));
-	        this.tableLayoutPanel4.Controls.Add(this.useTranslucentModListSelection, 0, 0);
-	        this.tableLayoutPanel4.Controls.Add(this.showHiddenEntriesCheckBox, 1, 0);
-	        this.tableLayoutPanel4.Controls.Add(this.hideRunX2Button, 0, 1);
-	        this.tableLayoutPanel4.Controls.Add(this.hideChallengeModeButton, 0, 2);
-	        this.tableLayoutPanel4.Location = new System.Drawing.Point(3, 20);
-	        this.tableLayoutPanel4.Name = "tableLayoutPanel4";
-	        this.tableLayoutPanel4.RowCount = 3;
-	        this.tableLayoutPanel4.RowStyles.Add(new System.Windows.Forms.RowStyle());
-	        this.tableLayoutPanel4.RowStyles.Add(new System.Windows.Forms.RowStyle());
-	        this.tableLayoutPanel4.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-	        this.tableLayoutPanel4.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-	        this.tableLayoutPanel4.Size = new System.Drawing.Size(641, 85);
-	        this.tableLayoutPanel4.TabIndex = 6;
-	        // 
-	        // hideRunX2Button
-	        // 
-	        this.hideRunX2Button.AutoSize = true;
-	        this.tableLayoutPanel4.SetColumnSpan(this.hideRunX2Button, 2);
-	        this.hideRunX2Button.Location = new System.Drawing.Point(3, 29);
-	        this.hideRunX2Button.Name = "hideRunX2Button";
-	        this.hideRunX2Button.Padding = new System.Windows.Forms.Padding(3, 3, 0, 0);
-	        this.hideRunX2Button.Size = new System.Drawing.Size(278, 20);
-	        this.hideRunX2Button.TabIndex = 15;
-	        this.hideRunX2Button.Text = "Hide \"Run XCOM2\" button (only if WotC is available)";
-	        this.hideRunX2Button.UseVisualStyleBackColor = true;
-	        // 
-	        // hideChallengeModeButton
-	        // 
-	        this.hideChallengeModeButton.AutoSize = true;
-	        this.tableLayoutPanel4.SetColumnSpan(this.hideChallengeModeButton, 2);
-	        this.hideChallengeModeButton.Location = new System.Drawing.Point(3, 55);
-	        this.hideChallengeModeButton.Name = "hideChallengeModeButton";
-	        this.hideChallengeModeButton.Padding = new System.Windows.Forms.Padding(3, 3, 0, 0);
-	        this.hideChallengeModeButton.Size = new System.Drawing.Size(197, 20);
-	        this.hideChallengeModeButton.TabIndex = 16;
-	        this.hideChallengeModeButton.Text = "Hide \"Run Challenge Mode\" button";
-	        this.hideChallengeModeButton.UseVisualStyleBackColor = true;
-	        // 
-	        // SettingsDialog
-	        // 
-	        this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-	        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-	        this.ClientSize = new System.Drawing.Size(679, 538);
-	        this.Controls.Add(this.groupBox4);
-	        this.Controls.Add(this.groupBox3);
-	        this.Controls.Add(this.bOK);
-	        this.Controls.Add(this.bCancel);
-	        this.Controls.Add(this.groupBox2);
-	        this.Controls.Add(this.groupBox1);
-	        this.Icon = global::XCOM2Launcher.Properties.Resources.xcom;
-	        this.Name = "SettingsDialog";
-	        this.ShowInTaskbar = false;
-	        this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-	        this.Text = "Settings";
-	        this.Shown += new System.EventHandler(this.SettingsDialog_Shown);
-	        this.groupBox1.ResumeLayout(false);
-	        this.tableLayoutPanel2.ResumeLayout(false);
-	        this.tableLayoutPanel2.PerformLayout();
-	        this.flowLayoutPanel1.ResumeLayout(false);
-	        this.groupBox2.ResumeLayout(false);
-	        this.tableLayoutPanel3.ResumeLayout(false);
-	        this.tableLayoutPanel3.PerformLayout();
-	        this.groupBox3.ResumeLayout(false);
-	        this.tableLayoutPanel1.ResumeLayout(false);
-	        this.tableLayoutPanel1.PerformLayout();
-	        this.groupBox4.ResumeLayout(false);
-	        this.tableLayoutPanel4.ResumeLayout(false);
-	        this.tableLayoutPanel4.PerformLayout();
-	        this.ResumeLayout(false);
+			this.components = new System.ComponentModel.Container();
+			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(SettingsDialog));
+			this.groupBox1 = new System.Windows.Forms.GroupBox();
+			this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
+			this.quickArgumentsTextBox = new XCOM2Launcher.UserElements.AutoCompleteTextBox();
+			this.label2 = new System.Windows.Forms.Label();
+			this.label1 = new System.Windows.Forms.Label();
+			this.modPathsListbox = new System.Windows.Forms.ListBox();
+			this.ShowQuickLaunchArgumentsToggle = new System.Windows.Forms.CheckBox();
+			this.label3 = new System.Windows.Forms.Label();
+			this.label4 = new System.Windows.Forms.Label();
+			this.gamePathTextBox = new System.Windows.Forms.TextBox();
+			this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
+			this.addModPathButton = new System.Windows.Forms.Button();
+			this.removeModPathButton = new System.Windows.Forms.Button();
+			this.browseGamePathButton = new System.Windows.Forms.Button();
+			this.argumentsTextBox = new XCOM2Launcher.UserElements.AutoCompleteTextBox();
+			this.groupBox2 = new System.Windows.Forms.GroupBox();
+			this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
+			this.updateModsOnStartup = new System.Windows.Forms.CheckBox();
+			this.useModSpecifiedCategoriesCheckBox = new System.Windows.Forms.CheckBox();
+			this.autoNumberModIndexesCheckBox = new System.Windows.Forms.CheckBox();
+			this.neverAdoptTagsAndCatFromprofile = new System.Windows.Forms.CheckBox();
+			this.useDuplicateModWorkaround = new System.Windows.Forms.CheckBox();
+			this.onlyUpdateEnabledAndNew = new System.Windows.Forms.CheckBox();
+			this.showHiddenEntriesCheckBox = new System.Windows.Forms.CheckBox();
+			this.useTranslucentModListSelection = new System.Windows.Forms.CheckBox();
+			this.useSentry = new System.Windows.Forms.CheckBox();
+			this.closeAfterLaunchCheckBox = new System.Windows.Forms.CheckBox();
+			this.searchForUpdatesCheckBox = new System.Windows.Forms.CheckBox();
+			this.checkForPreReleaseUpdates = new System.Windows.Forms.CheckBox();
+			this.toolTip = new System.Windows.Forms.ToolTip(this.components);
+			this.allowMutipleInstances = new System.Windows.Forms.CheckBox();
+			this.bOK = new System.Windows.Forms.Button();
+			this.bCancel = new System.Windows.Forms.Button();
+			this.groupBox3 = new System.Windows.Forms.GroupBox();
+			this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+			this.groupBox4 = new System.Windows.Forms.GroupBox();
+			this.tableLayoutPanel4 = new System.Windows.Forms.TableLayoutPanel();
+			this.hideRunX2Button = new System.Windows.Forms.CheckBox();
+			this.hideChallengeModeButton = new System.Windows.Forms.CheckBox();
+			this.groupBox1.SuspendLayout();
+			this.tableLayoutPanel2.SuspendLayout();
+			this.flowLayoutPanel1.SuspendLayout();
+			this.groupBox2.SuspendLayout();
+			this.tableLayoutPanel3.SuspendLayout();
+			this.groupBox3.SuspendLayout();
+			this.tableLayoutPanel1.SuspendLayout();
+			this.groupBox4.SuspendLayout();
+			this.tableLayoutPanel4.SuspendLayout();
+			this.SuspendLayout();
+			// 
+			// groupBox1
+			// 
+			this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+			this.groupBox1.Controls.Add(this.tableLayoutPanel2);
+			this.groupBox1.Location = new System.Drawing.Point(12, 8);
+			this.groupBox1.Name = "groupBox1";
+			this.groupBox1.Size = new System.Drawing.Size(655, 200);
+			this.groupBox1.TabIndex = 9;
+			this.groupBox1.TabStop = false;
+			this.groupBox1.Text = "Game options";
+			// 
+			// tableLayoutPanel2
+			// 
+			this.tableLayoutPanel2.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+			this.tableLayoutPanel2.ColumnCount = 3;
+			this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 130F));
+			this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+			this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+			this.tableLayoutPanel2.Controls.Add(this.quickArgumentsTextBox, 1, 3);
+			this.tableLayoutPanel2.Controls.Add(this.label2, 0, 3);
+			this.tableLayoutPanel2.Controls.Add(this.label1, 0, 2);
+			this.tableLayoutPanel2.Controls.Add(this.modPathsListbox, 1, 1);
+			this.tableLayoutPanel2.Controls.Add(this.ShowQuickLaunchArgumentsToggle, 2, 3);
+			this.tableLayoutPanel2.Controls.Add(this.label3, 0, 0);
+			this.tableLayoutPanel2.Controls.Add(this.label4, 0, 1);
+			this.tableLayoutPanel2.Controls.Add(this.gamePathTextBox, 1, 0);
+			this.tableLayoutPanel2.Controls.Add(this.flowLayoutPanel1, 2, 1);
+			this.tableLayoutPanel2.Controls.Add(this.browseGamePathButton, 2, 0);
+			this.tableLayoutPanel2.Controls.Add(this.argumentsTextBox, 1, 2);
+			this.tableLayoutPanel2.Location = new System.Drawing.Point(3, 19);
+			this.tableLayoutPanel2.Name = "tableLayoutPanel2";
+			this.tableLayoutPanel2.RowCount = 4;
+			this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
+			this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+			this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 25F));
+			this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 25F));
+			this.tableLayoutPanel2.Size = new System.Drawing.Size(641, 175);
+			this.tableLayoutPanel2.TabIndex = 6;
+			// 
+			// quickArgumentsTextBox
+			// 
+			this.quickArgumentsTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.quickArgumentsTextBox.Location = new System.Drawing.Point(133, 153);
+			this.quickArgumentsTextBox.Name = "quickArgumentsTextBox";
+			this.quickArgumentsTextBox.Size = new System.Drawing.Size(432, 20);
+			this.quickArgumentsTextBox.TabIndex = 16;
+			this.quickArgumentsTextBox.Values = new string[0];
+			// 
+			// label2
+			// 
+			this.label2.AutoSize = true;
+			this.label2.Location = new System.Drawing.Point(4, 156);
+			this.label2.Margin = new System.Windows.Forms.Padding(4, 6, 3, 0);
+			this.label2.Name = "label2";
+			this.label2.Size = new System.Drawing.Size(119, 13);
+			this.label2.TabIndex = 14;
+			this.label2.Text = "Quick toggle arguments";
+			// 
+			// label1
+			// 
+			this.label1.AutoSize = true;
+			this.label1.Location = new System.Drawing.Point(4, 131);
+			this.label1.Margin = new System.Windows.Forms.Padding(4, 6, 3, 0);
+			this.label1.Name = "label1";
+			this.label1.Size = new System.Drawing.Size(89, 13);
+			this.label1.TabIndex = 0;
+			this.label1.Text = "Active arguments";
+			// 
+			// modPathsListbox
+			// 
+			this.modPathsListbox.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.modPathsListbox.FormattingEnabled = true;
+			this.modPathsListbox.Location = new System.Drawing.Point(133, 33);
+			this.modPathsListbox.Name = "modPathsListbox";
+			this.modPathsListbox.Size = new System.Drawing.Size(432, 89);
+			this.modPathsListbox.TabIndex = 4;
+			// 
+			// ShowQuickLaunchArgumentsToggle
+			// 
+			this.ShowQuickLaunchArgumentsToggle.AutoSize = true;
+			this.ShowQuickLaunchArgumentsToggle.Location = new System.Drawing.Point(571, 153);
+			this.ShowQuickLaunchArgumentsToggle.Name = "ShowQuickLaunchArgumentsToggle";
+			this.ShowQuickLaunchArgumentsToggle.Padding = new System.Windows.Forms.Padding(3, 3, 0, 0);
+			this.ShowQuickLaunchArgumentsToggle.Size = new System.Drawing.Size(62, 19);
+			this.ShowQuickLaunchArgumentsToggle.TabIndex = 17;
+			this.ShowQuickLaunchArgumentsToggle.Text = "Enable";
+			this.toolTip.SetToolTip(this.ShowQuickLaunchArgumentsToggle, "If enabled, a combo-box that allows to quickly toggle the\r\nspecified quick toggle" +
+        " arguments is displayed on the main screen.");
+			this.ShowQuickLaunchArgumentsToggle.UseVisualStyleBackColor = true;
+			// 
+			// label3
+			// 
+			this.label3.AutoSize = true;
+			this.label3.Location = new System.Drawing.Point(4, 6);
+			this.label3.Margin = new System.Windows.Forms.Padding(4, 6, 3, 0);
+			this.label3.Name = "label3";
+			this.label3.Size = new System.Drawing.Size(56, 13);
+			this.label3.TabIndex = 0;
+			this.label3.Text = "Base Path";
+			// 
+			// label4
+			// 
+			this.label4.AutoSize = true;
+			this.label4.Location = new System.Drawing.Point(4, 36);
+			this.label4.Margin = new System.Windows.Forms.Padding(4, 6, 3, 0);
+			this.label4.Name = "label4";
+			this.label4.Size = new System.Drawing.Size(81, 13);
+			this.label4.TabIndex = 2;
+			this.label4.Text = "Mod Directories";
+			// 
+			// gamePathTextBox
+			// 
+			this.gamePathTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.gamePathTextBox.Location = new System.Drawing.Point(133, 3);
+			this.gamePathTextBox.Name = "gamePathTextBox";
+			this.gamePathTextBox.Size = new System.Drawing.Size(432, 20);
+			this.gamePathTextBox.TabIndex = 10;
+			// 
+			// flowLayoutPanel1
+			// 
+			this.flowLayoutPanel1.Controls.Add(this.addModPathButton);
+			this.flowLayoutPanel1.Controls.Add(this.removeModPathButton);
+			this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.flowLayoutPanel1.Location = new System.Drawing.Point(568, 30);
+			this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(0);
+			this.flowLayoutPanel1.Name = "flowLayoutPanel1";
+			this.flowLayoutPanel1.Size = new System.Drawing.Size(73, 95);
+			this.flowLayoutPanel1.TabIndex = 12;
+			// 
+			// addModPathButton
+			// 
+			this.addModPathButton.Location = new System.Drawing.Point(3, 3);
+			this.addModPathButton.Name = "addModPathButton";
+			this.addModPathButton.Size = new System.Drawing.Size(67, 24);
+			this.addModPathButton.TabIndex = 6;
+			this.addModPathButton.Text = "Add";
+			this.addModPathButton.UseVisualStyleBackColor = true;
+			this.addModPathButton.Click += new System.EventHandler(this.AddModPathButtonOnClick);
+			// 
+			// removeModPathButton
+			// 
+			this.removeModPathButton.Location = new System.Drawing.Point(3, 33);
+			this.removeModPathButton.Name = "removeModPathButton";
+			this.removeModPathButton.Size = new System.Drawing.Size(67, 24);
+			this.removeModPathButton.TabIndex = 8;
+			this.removeModPathButton.Text = "Remove";
+			this.removeModPathButton.UseVisualStyleBackColor = true;
+			this.removeModPathButton.Click += new System.EventHandler(this.RemoveModPathButtonOnClick);
+			// 
+			// browseGamePathButton
+			// 
+			this.browseGamePathButton.Location = new System.Drawing.Point(571, 3);
+			this.browseGamePathButton.Name = "browseGamePathButton";
+			this.browseGamePathButton.Size = new System.Drawing.Size(67, 24);
+			this.browseGamePathButton.TabIndex = 14;
+			this.browseGamePathButton.Text = "Browse";
+			this.browseGamePathButton.UseVisualStyleBackColor = true;
+			this.browseGamePathButton.Click += new System.EventHandler(this.BrowseGamePathButtonOnClick);
+			// 
+			// argumentsTextBox
+			// 
+			this.argumentsTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
+			this.argumentsTextBox.Location = new System.Drawing.Point(133, 128);
+			this.argumentsTextBox.Name = "argumentsTextBox";
+			this.argumentsTextBox.Size = new System.Drawing.Size(432, 20);
+			this.argumentsTextBox.TabIndex = 15;
+			this.argumentsTextBox.Values = new string[0];
+			// 
+			// groupBox2
+			// 
+			this.groupBox2.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+			this.groupBox2.Controls.Add(this.tableLayoutPanel3);
+			this.groupBox2.Location = new System.Drawing.Point(12, 297);
+			this.groupBox2.Name = "groupBox2";
+			this.groupBox2.Size = new System.Drawing.Size(655, 82);
+			this.groupBox2.TabIndex = 10;
+			this.groupBox2.TabStop = false;
+			this.groupBox2.Text = "Usability";
+			// 
+			// tableLayoutPanel3
+			// 
+			this.tableLayoutPanel3.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+			this.tableLayoutPanel3.ColumnCount = 3;
+			this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 33.33333F));
+			this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 33.33334F));
+			this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 33.33334F));
+			this.tableLayoutPanel3.Controls.Add(this.updateModsOnStartup, 0, 1);
+			this.tableLayoutPanel3.Controls.Add(this.useModSpecifiedCategoriesCheckBox, 0, 1);
+			this.tableLayoutPanel3.Controls.Add(this.autoNumberModIndexesCheckBox, 0, 0);
+			this.tableLayoutPanel3.Controls.Add(this.neverAdoptTagsAndCatFromprofile, 1, 0);
+			this.tableLayoutPanel3.Controls.Add(this.useDuplicateModWorkaround, 2, 0);
+			this.tableLayoutPanel3.Controls.Add(this.onlyUpdateEnabledAndNew, 2, 1);
+			this.tableLayoutPanel3.Location = new System.Drawing.Point(3, 20);
+			this.tableLayoutPanel3.Name = "tableLayoutPanel3";
+			this.tableLayoutPanel3.RowCount = 2;
+			this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
+			this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
+			this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+			this.tableLayoutPanel3.Size = new System.Drawing.Size(641, 56);
+			this.tableLayoutPanel3.TabIndex = 6;
+			// 
+			// updateModsOnStartup
+			// 
+			this.updateModsOnStartup.AutoSize = true;
+			this.updateModsOnStartup.Location = new System.Drawing.Point(216, 29);
+			this.updateModsOnStartup.Name = "updateModsOnStartup";
+			this.updateModsOnStartup.Padding = new System.Windows.Forms.Padding(3, 3, 0, 0);
+			this.updateModsOnStartup.Size = new System.Drawing.Size(142, 20);
+			this.updateModsOnStartup.TabIndex = 18;
+			this.updateModsOnStartup.Text = "Update mods on startup";
+			this.toolTip.SetToolTip(this.updateModsOnStartup, resources.GetString("updateModsOnStartup.ToolTip"));
+			this.updateModsOnStartup.UseVisualStyleBackColor = true;
+			this.updateModsOnStartup.CheckedChanged += new System.EventHandler(this.updateModsOnStartup_CheckedChanged);
+			// 
+			// useModSpecifiedCategoriesCheckBox
+			// 
+			this.useModSpecifiedCategoriesCheckBox.AutoSize = true;
+			this.useModSpecifiedCategoriesCheckBox.Location = new System.Drawing.Point(3, 29);
+			this.useModSpecifiedCategoriesCheckBox.Name = "useModSpecifiedCategoriesCheckBox";
+			this.useModSpecifiedCategoriesCheckBox.Padding = new System.Windows.Forms.Padding(3, 3, 0, 0);
+			this.useModSpecifiedCategoriesCheckBox.Size = new System.Drawing.Size(168, 20);
+			this.useModSpecifiedCategoriesCheckBox.TabIndex = 15;
+			this.useModSpecifiedCategoriesCheckBox.Text = "Use mod-specified categories";
+			this.toolTip.SetToolTip(this.useModSpecifiedCategoriesCheckBox, "Toggle whether new mods appear in their specified \r\ndefault category (turn off to" +
+        " have all mods appear in Unsorted).");
+			this.useModSpecifiedCategoriesCheckBox.UseVisualStyleBackColor = true;
+			// 
+			// autoNumberModIndexesCheckBox
+			// 
+			this.autoNumberModIndexesCheckBox.AutoSize = true;
+			this.autoNumberModIndexesCheckBox.Location = new System.Drawing.Point(3, 3);
+			this.autoNumberModIndexesCheckBox.Name = "autoNumberModIndexesCheckBox";
+			this.autoNumberModIndexesCheckBox.Padding = new System.Windows.Forms.Padding(3, 3, 0, 0);
+			this.autoNumberModIndexesCheckBox.Size = new System.Drawing.Size(151, 20);
+			this.autoNumberModIndexesCheckBox.TabIndex = 14;
+			this.autoNumberModIndexesCheckBox.Text = "Auto-number mod indexes";
+			this.toolTip.SetToolTip(this.autoNumberModIndexesCheckBox, "Auto-number mod indexes, when \r\none is changed (turn off to edit manually).");
+			this.autoNumberModIndexesCheckBox.UseVisualStyleBackColor = true;
+			// 
+			// neverAdoptTagsAndCatFromprofile
+			// 
+			this.neverAdoptTagsAndCatFromprofile.AutoSize = true;
+			this.neverAdoptTagsAndCatFromprofile.Location = new System.Drawing.Point(216, 3);
+			this.neverAdoptTagsAndCatFromprofile.Name = "neverAdoptTagsAndCatFromprofile";
+			this.neverAdoptTagsAndCatFromprofile.Padding = new System.Windows.Forms.Padding(3, 3, 0, 0);
+			this.neverAdoptTagsAndCatFromprofile.Size = new System.Drawing.Size(185, 20);
+			this.neverAdoptTagsAndCatFromprofile.TabIndex = 16;
+			this.neverAdoptTagsAndCatFromprofile.Text = "Never import tags and categories";
+			this.toolTip.SetToolTip(this.neverAdoptTagsAndCatFromprofile, "If enabled, currently assigned tags and categories\r\nwill always be preserved when" +
+        " importing profiles.");
+			this.neverAdoptTagsAndCatFromprofile.UseVisualStyleBackColor = true;
+			// 
+			// useDuplicateModWorkaround
+			// 
+			this.useDuplicateModWorkaround.AutoSize = true;
+			this.useDuplicateModWorkaround.Location = new System.Drawing.Point(429, 3);
+			this.useDuplicateModWorkaround.Name = "useDuplicateModWorkaround";
+			this.useDuplicateModWorkaround.Padding = new System.Windows.Forms.Padding(3, 3, 0, 0);
+			this.useDuplicateModWorkaround.Size = new System.Drawing.Size(204, 20);
+			this.useDuplicateModWorkaround.TabIndex = 17;
+			this.useDuplicateModWorkaround.Text = "Enable duplicate mod ID workaround";
+			this.toolTip.SetToolTip(this.useDuplicateModWorkaround, resources.GetString("useDuplicateModWorkaround.ToolTip"));
+			this.useDuplicateModWorkaround.UseVisualStyleBackColor = true;
+			// 
+			// onlyUpdateEnabledAndNew
+			// 
+			this.onlyUpdateEnabledAndNew.AutoSize = true;
+			this.onlyUpdateEnabledAndNew.Location = new System.Drawing.Point(429, 29);
+			this.onlyUpdateEnabledAndNew.Name = "onlyUpdateEnabledAndNew";
+			this.onlyUpdateEnabledAndNew.Padding = new System.Windows.Forms.Padding(3, 3, 0, 0);
+			this.onlyUpdateEnabledAndNew.Size = new System.Drawing.Size(190, 20);
+			this.onlyUpdateEnabledAndNew.TabIndex = 19;
+			this.onlyUpdateEnabledAndNew.Text = "Only update enabled or new mods";
+			this.toolTip.SetToolTip(this.onlyUpdateEnabledAndNew, resources.GetString("onlyUpdateEnabledAndNew.ToolTip"));
+			this.onlyUpdateEnabledAndNew.UseVisualStyleBackColor = true;
+			// 
+			// showHiddenEntriesCheckBox
+			// 
+			this.showHiddenEntriesCheckBox.AutoSize = true;
+			this.showHiddenEntriesCheckBox.Location = new System.Drawing.Point(216, 3);
+			this.showHiddenEntriesCheckBox.Name = "showHiddenEntriesCheckBox";
+			this.showHiddenEntriesCheckBox.Padding = new System.Windows.Forms.Padding(3, 3, 0, 0);
+			this.showHiddenEntriesCheckBox.Size = new System.Drawing.Size(119, 20);
+			this.showHiddenEntriesCheckBox.TabIndex = 9;
+			this.showHiddenEntriesCheckBox.Text = "Show hidden mods";
+			this.toolTip.SetToolTip(this.showHiddenEntriesCheckBox, "If enabled, hidden mod entries will \r\nbe shown in the mod list.");
+			this.showHiddenEntriesCheckBox.UseVisualStyleBackColor = true;
+			// 
+			// useTranslucentModListSelection
+			// 
+			this.useTranslucentModListSelection.AutoSize = true;
+			this.useTranslucentModListSelection.Location = new System.Drawing.Point(3, 3);
+			this.useTranslucentModListSelection.Name = "useTranslucentModListSelection";
+			this.useTranslucentModListSelection.Padding = new System.Windows.Forms.Padding(3, 3, 0, 0);
+			this.useTranslucentModListSelection.Size = new System.Drawing.Size(183, 20);
+			this.useTranslucentModListSelection.TabIndex = 14;
+			this.useTranslucentModListSelection.Text = "Use translucent modlist selection";
+			this.toolTip.SetToolTip(this.useTranslucentModListSelection, "If enabled, selected items in the mod lists will be highlighted with a\r\ntransluce" +
+        "nt selection color instead of the default opaque blue.");
+			this.useTranslucentModListSelection.UseVisualStyleBackColor = true;
+			// 
+			// useSentry
+			// 
+			this.useSentry.AutoSize = true;
+			this.useSentry.Location = new System.Drawing.Point(429, 3);
+			this.useSentry.Name = "useSentry";
+			this.useSentry.Padding = new System.Windows.Forms.Padding(3, 3, 0, 0);
+			this.useSentry.Size = new System.Drawing.Size(170, 20);
+			this.useSentry.TabIndex = 17;
+			this.useSentry.Text = "Send anonymous error reports";
+			this.toolTip.SetToolTip(this.useSentry, "If enabled, critical errors or other \r\npotential issues are automatically reporte" +
+        "d to\r\nour X2CommunityCore Sentry.io account.");
+			this.useSentry.UseVisualStyleBackColor = true;
+			// 
+			// closeAfterLaunchCheckBox
+			// 
+			this.closeAfterLaunchCheckBox.AutoSize = true;
+			this.closeAfterLaunchCheckBox.Location = new System.Drawing.Point(216, 29);
+			this.closeAfterLaunchCheckBox.Name = "closeAfterLaunchCheckBox";
+			this.closeAfterLaunchCheckBox.Padding = new System.Windows.Forms.Padding(3, 3, 0, 0);
+			this.closeAfterLaunchCheckBox.Size = new System.Drawing.Size(114, 20);
+			this.closeAfterLaunchCheckBox.TabIndex = 7;
+			this.closeAfterLaunchCheckBox.Text = "Close after launch";
+			this.toolTip.SetToolTip(this.closeAfterLaunchCheckBox, "Close the launcher after launching the game.");
+			this.closeAfterLaunchCheckBox.UseVisualStyleBackColor = true;
+			// 
+			// searchForUpdatesCheckBox
+			// 
+			this.searchForUpdatesCheckBox.AutoSize = true;
+			this.searchForUpdatesCheckBox.Location = new System.Drawing.Point(3, 3);
+			this.searchForUpdatesCheckBox.Name = "searchForUpdatesCheckBox";
+			this.searchForUpdatesCheckBox.Padding = new System.Windows.Forms.Padding(3, 3, 0, 0);
+			this.searchForUpdatesCheckBox.Size = new System.Drawing.Size(116, 20);
+			this.searchForUpdatesCheckBox.TabIndex = 10;
+			this.searchForUpdatesCheckBox.Text = "Check for updates";
+			this.toolTip.SetToolTip(this.searchForUpdatesCheckBox, "Check if a new Version is available on startup.");
+			this.searchForUpdatesCheckBox.UseVisualStyleBackColor = true;
+			this.searchForUpdatesCheckBox.CheckedChanged += new System.EventHandler(this.searchForUpdatesCheckBox_CheckedChanged);
+			// 
+			// checkForPreReleaseUpdates
+			// 
+			this.checkForPreReleaseUpdates.AutoSize = true;
+			this.checkForPreReleaseUpdates.Location = new System.Drawing.Point(216, 3);
+			this.checkForPreReleaseUpdates.Name = "checkForPreReleaseUpdates";
+			this.checkForPreReleaseUpdates.Padding = new System.Windows.Forms.Padding(3, 3, 0, 0);
+			this.checkForPreReleaseUpdates.Size = new System.Drawing.Size(166, 20);
+			this.checkForPreReleaseUpdates.TabIndex = 18;
+			this.checkForPreReleaseUpdates.Text = "Include Pre-Release updates";
+			this.toolTip.SetToolTip(this.checkForPreReleaseUpdates, "Enabled this option, if you wold like to be notified about Pre-Release versions.");
+			this.checkForPreReleaseUpdates.UseVisualStyleBackColor = true;
+			// 
+			// toolTip
+			// 
+			this.toolTip.AutoPopDelay = 10000;
+			this.toolTip.InitialDelay = 300;
+			this.toolTip.IsBalloon = true;
+			this.toolTip.ReshowDelay = 100;
+			// 
+			// allowMutipleInstances
+			// 
+			this.allowMutipleInstances.AutoSize = true;
+			this.allowMutipleInstances.Location = new System.Drawing.Point(3, 29);
+			this.allowMutipleInstances.Name = "allowMutipleInstances";
+			this.allowMutipleInstances.Padding = new System.Windows.Forms.Padding(3, 3, 0, 0);
+			this.allowMutipleInstances.Size = new System.Drawing.Size(140, 20);
+			this.allowMutipleInstances.TabIndex = 19;
+			this.allowMutipleInstances.Text = "Allow multiple instances";
+			this.toolTip.SetToolTip(this.allowMutipleInstances, "If enabled, multiple instances of AML can be run in parallel.");
+			this.allowMutipleInstances.UseVisualStyleBackColor = true;
+			// 
+			// bOK
+			// 
+			this.bOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+			this.bOK.Location = new System.Drawing.Point(453, 502);
+			this.bOK.Name = "bOK";
+			this.bOK.Size = new System.Drawing.Size(104, 24);
+			this.bOK.TabIndex = 12;
+			this.bOK.Text = "OK";
+			this.bOK.UseVisualStyleBackColor = true;
+			this.bOK.Click += new System.EventHandler(this.bOK_Click);
+			// 
+			// bCancel
+			// 
+			this.bCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+			this.bCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+			this.bCancel.Location = new System.Drawing.Point(563, 502);
+			this.bCancel.Name = "bCancel";
+			this.bCancel.Size = new System.Drawing.Size(104, 24);
+			this.bCancel.TabIndex = 11;
+			this.bCancel.Text = "Cancel";
+			this.bCancel.UseVisualStyleBackColor = true;
+			// 
+			// groupBox3
+			// 
+			this.groupBox3.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+			this.groupBox3.Controls.Add(this.tableLayoutPanel1);
+			this.groupBox3.Location = new System.Drawing.Point(12, 214);
+			this.groupBox3.Name = "groupBox3";
+			this.groupBox3.Size = new System.Drawing.Size(655, 77);
+			this.groupBox3.TabIndex = 13;
+			this.groupBox3.TabStop = false;
+			this.groupBox3.Text = "Application";
+			// 
+			// tableLayoutPanel1
+			// 
+			this.tableLayoutPanel1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+			this.tableLayoutPanel1.ColumnCount = 3;
+			this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 33.33333F));
+			this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 33.33334F));
+			this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 33.33334F));
+			this.tableLayoutPanel1.Controls.Add(this.searchForUpdatesCheckBox, 0, 0);
+			this.tableLayoutPanel1.Controls.Add(this.checkForPreReleaseUpdates, 1, 0);
+			this.tableLayoutPanel1.Controls.Add(this.useSentry, 2, 0);
+			this.tableLayoutPanel1.Controls.Add(this.allowMutipleInstances, 0, 1);
+			this.tableLayoutPanel1.Controls.Add(this.closeAfterLaunchCheckBox, 1, 1);
+			this.tableLayoutPanel1.Location = new System.Drawing.Point(3, 19);
+			this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+			this.tableLayoutPanel1.RowCount = 2;
+			this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+			this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+			this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+			this.tableLayoutPanel1.Size = new System.Drawing.Size(641, 52);
+			this.tableLayoutPanel1.TabIndex = 0;
+			// 
+			// groupBox4
+			// 
+			this.groupBox4.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+			this.groupBox4.Controls.Add(this.tableLayoutPanel4);
+			this.groupBox4.Location = new System.Drawing.Point(12, 385);
+			this.groupBox4.Name = "groupBox4";
+			this.groupBox4.Size = new System.Drawing.Size(655, 111);
+			this.groupBox4.TabIndex = 11;
+			this.groupBox4.TabStop = false;
+			this.groupBox4.Text = "User interface";
+			// 
+			// tableLayoutPanel4
+			// 
+			this.tableLayoutPanel4.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+			this.tableLayoutPanel4.ColumnCount = 3;
+			this.tableLayoutPanel4.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 33.33333F));
+			this.tableLayoutPanel4.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 33.33334F));
+			this.tableLayoutPanel4.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 33.33334F));
+			this.tableLayoutPanel4.Controls.Add(this.useTranslucentModListSelection, 0, 0);
+			this.tableLayoutPanel4.Controls.Add(this.showHiddenEntriesCheckBox, 1, 0);
+			this.tableLayoutPanel4.Controls.Add(this.hideRunX2Button, 0, 1);
+			this.tableLayoutPanel4.Controls.Add(this.hideChallengeModeButton, 0, 2);
+			this.tableLayoutPanel4.Location = new System.Drawing.Point(3, 20);
+			this.tableLayoutPanel4.Name = "tableLayoutPanel4";
+			this.tableLayoutPanel4.RowCount = 3;
+			this.tableLayoutPanel4.RowStyles.Add(new System.Windows.Forms.RowStyle());
+			this.tableLayoutPanel4.RowStyles.Add(new System.Windows.Forms.RowStyle());
+			this.tableLayoutPanel4.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+			this.tableLayoutPanel4.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+			this.tableLayoutPanel4.Size = new System.Drawing.Size(641, 85);
+			this.tableLayoutPanel4.TabIndex = 6;
+			// 
+			// hideRunX2Button
+			// 
+			this.hideRunX2Button.AutoSize = true;
+			this.tableLayoutPanel4.SetColumnSpan(this.hideRunX2Button, 2);
+			this.hideRunX2Button.Location = new System.Drawing.Point(3, 29);
+			this.hideRunX2Button.Name = "hideRunX2Button";
+			this.hideRunX2Button.Padding = new System.Windows.Forms.Padding(3, 3, 0, 0);
+			this.hideRunX2Button.Size = new System.Drawing.Size(278, 20);
+			this.hideRunX2Button.TabIndex = 15;
+			this.hideRunX2Button.Text = "Hide \"Run XCOM2\" button (only if WotC is available)";
+			this.hideRunX2Button.UseVisualStyleBackColor = true;
+			// 
+			// hideChallengeModeButton
+			// 
+			this.hideChallengeModeButton.AutoSize = true;
+			this.tableLayoutPanel4.SetColumnSpan(this.hideChallengeModeButton, 2);
+			this.hideChallengeModeButton.Location = new System.Drawing.Point(3, 55);
+			this.hideChallengeModeButton.Name = "hideChallengeModeButton";
+			this.hideChallengeModeButton.Padding = new System.Windows.Forms.Padding(3, 3, 0, 0);
+			this.hideChallengeModeButton.Size = new System.Drawing.Size(197, 20);
+			this.hideChallengeModeButton.TabIndex = 16;
+			this.hideChallengeModeButton.Text = "Hide \"Run Challenge Mode\" button";
+			this.hideChallengeModeButton.UseVisualStyleBackColor = true;
+			// 
+			// SettingsDialog
+			// 
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.ClientSize = new System.Drawing.Size(679, 538);
+			this.Controls.Add(this.groupBox4);
+			this.Controls.Add(this.groupBox3);
+			this.Controls.Add(this.bOK);
+			this.Controls.Add(this.bCancel);
+			this.Controls.Add(this.groupBox2);
+			this.Controls.Add(this.groupBox1);
+			this.Icon = global::XCOM2Launcher.Properties.Resources.xcom;
+			this.Name = "SettingsDialog";
+			this.ShowInTaskbar = false;
+			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+			this.Text = "Settings";
+			this.Shown += new System.EventHandler(this.SettingsDialog_Shown);
+			this.groupBox1.ResumeLayout(false);
+			this.tableLayoutPanel2.ResumeLayout(false);
+			this.tableLayoutPanel2.PerformLayout();
+			this.flowLayoutPanel1.ResumeLayout(false);
+			this.groupBox2.ResumeLayout(false);
+			this.tableLayoutPanel3.ResumeLayout(false);
+			this.tableLayoutPanel3.PerformLayout();
+			this.groupBox3.ResumeLayout(false);
+			this.tableLayoutPanel1.ResumeLayout(false);
+			this.tableLayoutPanel1.PerformLayout();
+			this.groupBox4.ResumeLayout(false);
+			this.tableLayoutPanel4.ResumeLayout(false);
+			this.tableLayoutPanel4.PerformLayout();
+			this.ResumeLayout(false);
+
         }
 
         #endregion

--- a/xcom2-launcher/xcom2-launcher/Forms/SettingsDialog.cs
+++ b/xcom2-launcher/xcom2-launcher/Forms/SettingsDialog.cs
@@ -18,6 +18,7 @@ namespace XCOM2Launcher.Forms
         {
             InitializeComponent();
 
+            CancelButton = bCancel;
             Settings = settings;
 
             // Init GUI and other locals

--- a/xcom2-launcher/xcom2-launcher/Forms/SettingsDialog.resx
+++ b/xcom2-launcher/xcom2-launcher/Forms/SettingsDialog.resx
@@ -120,6 +120,9 @@
   <metadata name="toolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <metadata name="toolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
   <data name="updateModsOnStartup.ToolTip" xml:space="preserve">
     <value>If you disable this option, mods will not be updated when AML is starting.
 If you have many mods, this can greatly reduce the time until AML is 

--- a/xcom2-launcher/xcom2-launcher/Forms/UnhandledExceptionDialog.Designer.cs
+++ b/xcom2-launcher/xcom2-launcher/Forms/UnhandledExceptionDialog.Designer.cs
@@ -23,145 +23,145 @@
         /// the contents of this method with the code editor.
         /// </summary>
         private void InitializeComponent() {
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(UnhandledExceptionDialog));
-            this.tException = new System.Windows.Forms.TextBox();
-            this.label1 = new System.Windows.Forms.Label();
-            this.pictureBox1 = new System.Windows.Forms.PictureBox();
-            this.bClose = new System.Windows.Forms.Button();
-            this.linkGithub = new System.Windows.Forms.LinkLabel();
-            this.linkDiscord = new System.Windows.Forms.LinkLabel();
-            this.linkAppFolder = new System.Windows.Forms.LinkLabel();
-            this.panel1 = new System.Windows.Forms.Panel();
-            this.bCopy = new System.Windows.Forms.Button();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
-            this.panel1.SuspendLayout();
-            this.SuspendLayout();
-            // 
-            // tException
-            // 
-            this.tException.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(UnhandledExceptionDialog));
+			this.tException = new System.Windows.Forms.TextBox();
+			this.label1 = new System.Windows.Forms.Label();
+			this.pictureBox1 = new System.Windows.Forms.PictureBox();
+			this.bClose = new System.Windows.Forms.Button();
+			this.linkGithub = new System.Windows.Forms.LinkLabel();
+			this.linkDiscord = new System.Windows.Forms.LinkLabel();
+			this.linkAppFolder = new System.Windows.Forms.LinkLabel();
+			this.panel1 = new System.Windows.Forms.Panel();
+			this.bCopy = new System.Windows.Forms.Button();
+			((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
+			this.panel1.SuspendLayout();
+			this.SuspendLayout();
+			// 
+			// tException
+			// 
+			this.tException.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.tException.Location = new System.Drawing.Point(12, 70);
-            this.tException.Multiline = true;
-            this.tException.Name = "tException";
-            this.tException.ReadOnly = true;
-            this.tException.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.tException.Size = new System.Drawing.Size(542, 221);
-            this.tException.TabIndex = 0;
-            // 
-            // label1
-            // 
-            this.label1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+			this.tException.Location = new System.Drawing.Point(12, 70);
+			this.tException.Multiline = true;
+			this.tException.Name = "tException";
+			this.tException.ReadOnly = true;
+			this.tException.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
+			this.tException.Size = new System.Drawing.Size(542, 221);
+			this.tException.TabIndex = 0;
+			// 
+			// label1
+			// 
+			this.label1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label1.Location = new System.Drawing.Point(12, 30);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(542, 34);
-            this.label1.TabIndex = 1;
-            this.label1.Text = "An unexpected problem caused AML to stop working correctly.";
-            this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-            // 
-            // pictureBox1
-            // 
-            this.pictureBox1.Dock = System.Windows.Forms.DockStyle.Top;
-            this.pictureBox1.Image = ((System.Drawing.Image)(resources.GetObject("pictureBox1.Image")));
-            this.pictureBox1.Location = new System.Drawing.Point(0, 0);
-            this.pictureBox1.Name = "pictureBox1";
-            this.pictureBox1.Size = new System.Drawing.Size(566, 24);
-            this.pictureBox1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
-            this.pictureBox1.TabIndex = 2;
-            this.pictureBox1.TabStop = false;
-            // 
-            // bClose
-            // 
-            this.bClose.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.bClose.Location = new System.Drawing.Point(440, 3);
-            this.bClose.Name = "bClose";
-            this.bClose.Size = new System.Drawing.Size(114, 23);
-            this.bClose.TabIndex = 4;
-            this.bClose.Text = "Close";
-            this.bClose.UseVisualStyleBackColor = true;
-            this.bClose.Click += new System.EventHandler(this.bClose_Click);
-            // 
-            // linkGithub
-            // 
-            this.linkGithub.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.linkGithub.AutoSize = true;
-            this.linkGithub.Location = new System.Drawing.Point(9, 294);
-            this.linkGithub.Name = "linkGithub";
-            this.linkGithub.Size = new System.Drawing.Size(117, 13);
-            this.linkGithub.TabIndex = 5;
-            this.linkGithub.TabStop = true;
-            this.linkGithub.Text = "Report issue on GitHub";
-            this.linkGithub.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkGithub_LinkClicked);
-            // 
-            // linkDiscord
-            // 
-            this.linkDiscord.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.linkDiscord.AutoSize = true;
-            this.linkDiscord.Location = new System.Drawing.Point(437, 294);
-            this.linkDiscord.Name = "linkDiscord";
-            this.linkDiscord.Size = new System.Drawing.Size(117, 13);
-            this.linkDiscord.TabIndex = 6;
-            this.linkDiscord.TabStop = true;
-            this.linkDiscord.Text = "Ask for help on Discord";
-            this.linkDiscord.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkDiscord_LinkClicked);
-            // 
-            // linkAppFolder
-            // 
-            this.linkAppFolder.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
-            this.linkAppFolder.AutoSize = true;
-            this.linkAppFolder.Location = new System.Drawing.Point(165, 294);
-            this.linkAppFolder.Name = "linkAppFolder";
-            this.linkAppFolder.Size = new System.Drawing.Size(237, 13);
-            this.linkAppFolder.TabIndex = 7;
-            this.linkAppFolder.TabStop = true;
-            this.linkAppFolder.Text = "See \'AML.log\' and \'error.log\' for additional details.";
-            this.linkAppFolder.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkAppFolder_LinkClicked);
-            // 
-            // panel1
-            // 
-            this.panel1.Controls.Add(this.bCopy);
-            this.panel1.Controls.Add(this.bClose);
-            this.panel1.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.panel1.Location = new System.Drawing.Point(0, 316);
-            this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(566, 31);
-            this.panel1.TabIndex = 8;
-            // 
-            // bCopy
-            // 
-            this.bCopy.Location = new System.Drawing.Point(12, 3);
-            this.bCopy.Name = "bCopy";
-            this.bCopy.Size = new System.Drawing.Size(114, 23);
-            this.bCopy.TabIndex = 5;
-            this.bCopy.Text = "Copy to clipboard";
-            this.bCopy.UseVisualStyleBackColor = true;
-            this.bCopy.Click += new System.EventHandler(this.bCopy_Click);
-            // 
-            // UnhandledExceptionDialog
-            // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(566, 347);
-            this.Controls.Add(this.panel1);
-            this.Controls.Add(this.linkAppFolder);
-            this.Controls.Add(this.linkDiscord);
-            this.Controls.Add(this.linkGithub);
-            this.Controls.Add(this.pictureBox1);
-            this.Controls.Add(this.label1);
-            this.Controls.Add(this.tException);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
-            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.MaximizeBox = false;
-            this.MinimizeBox = false;
-            this.Name = "UnhandledExceptionDialog";
-            this.Text = "Critical error";
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
-            this.panel1.ResumeLayout(false);
-            this.ResumeLayout(false);
-            this.PerformLayout();
+			this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.label1.Location = new System.Drawing.Point(12, 30);
+			this.label1.Name = "label1";
+			this.label1.Size = new System.Drawing.Size(542, 34);
+			this.label1.TabIndex = 1;
+			this.label1.Text = "An unexpected problem caused AML to stop working correctly.";
+			this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+			// 
+			// pictureBox1
+			// 
+			this.pictureBox1.Dock = System.Windows.Forms.DockStyle.Top;
+			this.pictureBox1.Image = ((System.Drawing.Image)(resources.GetObject("pictureBox1.Image")));
+			this.pictureBox1.Location = new System.Drawing.Point(0, 0);
+			this.pictureBox1.Name = "pictureBox1";
+			this.pictureBox1.Size = new System.Drawing.Size(566, 24);
+			this.pictureBox1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+			this.pictureBox1.TabIndex = 2;
+			this.pictureBox1.TabStop = false;
+			// 
+			// bClose
+			// 
+			this.bClose.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+			this.bClose.DialogResult = System.Windows.Forms.DialogResult.OK;
+			this.bClose.Location = new System.Drawing.Point(440, 3);
+			this.bClose.Name = "bClose";
+			this.bClose.Size = new System.Drawing.Size(114, 23);
+			this.bClose.TabIndex = 4;
+			this.bClose.Text = "&Close";
+			this.bClose.UseVisualStyleBackColor = true;
+			// 
+			// linkGithub
+			// 
+			this.linkGithub.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+			this.linkGithub.AutoSize = true;
+			this.linkGithub.Location = new System.Drawing.Point(9, 294);
+			this.linkGithub.Name = "linkGithub";
+			this.linkGithub.Size = new System.Drawing.Size(117, 13);
+			this.linkGithub.TabIndex = 5;
+			this.linkGithub.TabStop = true;
+			this.linkGithub.Text = "Report issue on GitHub";
+			this.linkGithub.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkGithub_LinkClicked);
+			// 
+			// linkDiscord
+			// 
+			this.linkDiscord.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+			this.linkDiscord.AutoSize = true;
+			this.linkDiscord.Location = new System.Drawing.Point(437, 294);
+			this.linkDiscord.Name = "linkDiscord";
+			this.linkDiscord.Size = new System.Drawing.Size(117, 13);
+			this.linkDiscord.TabIndex = 6;
+			this.linkDiscord.TabStop = true;
+			this.linkDiscord.Text = "Ask for help on Discord";
+			this.linkDiscord.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkDiscord_LinkClicked);
+			// 
+			// linkAppFolder
+			// 
+			this.linkAppFolder.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
+			this.linkAppFolder.AutoSize = true;
+			this.linkAppFolder.Location = new System.Drawing.Point(165, 294);
+			this.linkAppFolder.Name = "linkAppFolder";
+			this.linkAppFolder.Size = new System.Drawing.Size(237, 13);
+			this.linkAppFolder.TabIndex = 7;
+			this.linkAppFolder.TabStop = true;
+			this.linkAppFolder.Text = "See \'AML.log\' and \'error.log\' for additional details.";
+			this.linkAppFolder.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkAppFolder_LinkClicked);
+			// 
+			// panel1
+			// 
+			this.panel1.Controls.Add(this.bCopy);
+			this.panel1.Controls.Add(this.bClose);
+			this.panel1.Dock = System.Windows.Forms.DockStyle.Bottom;
+			this.panel1.Location = new System.Drawing.Point(0, 316);
+			this.panel1.Name = "panel1";
+			this.panel1.Size = new System.Drawing.Size(566, 31);
+			this.panel1.TabIndex = 8;
+			// 
+			// bCopy
+			// 
+			this.bCopy.Location = new System.Drawing.Point(12, 3);
+			this.bCopy.Name = "bCopy";
+			this.bCopy.Size = new System.Drawing.Size(114, 23);
+			this.bCopy.TabIndex = 5;
+			this.bCopy.Text = "C&opy to clipboard";
+			this.bCopy.UseVisualStyleBackColor = true;
+			this.bCopy.Click += new System.EventHandler(this.bCopy_Click);
+			// 
+			// UnhandledExceptionDialog
+			// 
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.ClientSize = new System.Drawing.Size(566, 347);
+			this.Controls.Add(this.panel1);
+			this.Controls.Add(this.linkAppFolder);
+			this.Controls.Add(this.linkDiscord);
+			this.Controls.Add(this.linkGithub);
+			this.Controls.Add(this.pictureBox1);
+			this.Controls.Add(this.label1);
+			this.Controls.Add(this.tException);
+			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+			this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+			this.MaximizeBox = false;
+			this.MinimizeBox = false;
+			this.Name = "UnhandledExceptionDialog";
+			this.Text = "Critical error";
+			((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
+			this.panel1.ResumeLayout(false);
+			this.ResumeLayout(false);
+			this.PerformLayout();
 
         }
 

--- a/xcom2-launcher/xcom2-launcher/Forms/UnhandledExceptionDialog.cs
+++ b/xcom2-launcher/xcom2-launcher/Forms/UnhandledExceptionDialog.cs
@@ -1,11 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 using XCOM2Launcher.Classes;
 using XCOM2Launcher.Helper;
@@ -15,6 +8,8 @@ namespace XCOM2Launcher.Forms {
         public UnhandledExceptionDialog(Exception ex) 
         {
             InitializeComponent();
+
+            CancelButton = bClose;
             
             tException.AppendText($"AML version: {Program.GetCurrentVersionString(true)}" + Environment.NewLine);
             tException.AppendText($"Sentry GUID: {GlobalSettings.Instance.Guid}" + Environment.NewLine);
@@ -35,10 +30,6 @@ namespace XCOM2Launcher.Forms {
         private void linkAppFolder_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e) 
         {
             Tools.StartProcess(Application.StartupPath);
-        }
-
-        private void bClose_Click(object sender, EventArgs e) {
-            Close();
         }
 
         private void bCopy_Click(object sender, EventArgs e)

--- a/xcom2-launcher/xcom2-launcher/Forms/UpdateAvailableDialog.Designer.cs
+++ b/xcom2-launcher/xcom2-launcher/Forms/UpdateAvailableDialog.Designer.cs
@@ -39,7 +39,7 @@
 			this.date_label = new System.Windows.Forms.Label();
 			this.date_value_label = new System.Windows.Forms.Label();
 			this.show_button = new System.Windows.Forms.Button();
-			this.close_button = new System.Windows.Forms.Button();
+			this.bClose = new System.Windows.Forms.Button();
 			this.lBetaVersion = new System.Windows.Forms.Label();
 			this.releaseNoteBrowser = new System.Windows.Forms.WebBrowser();
 			this.panel1 = new System.Windows.Forms.Panel();
@@ -141,17 +141,16 @@
 			this.show_button.UseVisualStyleBackColor = true;
 			this.show_button.Click += new System.EventHandler(this.show_button_Click);
 			// 
-			// close_button
+			// bClose
 			// 
-			this.close_button.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-			this.close_button.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-			this.close_button.Location = new System.Drawing.Point(474, 246);
-			this.close_button.Name = "close_button";
-			this.close_button.Size = new System.Drawing.Size(75, 23);
-			this.close_button.TabIndex = 1;
-			this.close_button.Text = "Close";
-			this.close_button.UseVisualStyleBackColor = true;
-			this.close_button.Click += new System.EventHandler(this.close_button_Click);
+			this.bClose.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+			this.bClose.DialogResult = System.Windows.Forms.DialogResult.OK;
+			this.bClose.Location = new System.Drawing.Point(474, 246);
+			this.bClose.Name = "bClose";
+			this.bClose.Size = new System.Drawing.Size(75, 23);
+			this.bClose.TabIndex = 1;
+			this.bClose.Text = "Close";
+			this.bClose.UseVisualStyleBackColor = true;
 			// 
 			// lBetaVersion
 			// 
@@ -204,7 +203,7 @@
 			this.Controls.Add(this.version_new_label);
 			this.Controls.Add(this.show_button);
 			this.Controls.Add(this.changelog_label);
-			this.Controls.Add(this.close_button);
+			this.Controls.Add(this.bClose);
 			this.Controls.Add(this.lBetaVersion);
 			this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
 			this.Name = "UpdateAvailableDialog";
@@ -226,7 +225,7 @@
         private System.Windows.Forms.Button show_button;
         private System.Windows.Forms.Label date_label;
         private System.Windows.Forms.Label date_value_label;
-        private System.Windows.Forms.Button close_button;
+        private System.Windows.Forms.Button bClose;
 		private System.Windows.Forms.Label lBetaVersion;
 		private System.Windows.Forms.WebBrowser releaseNoteBrowser;
         private System.Windows.Forms.Panel panel1;

--- a/xcom2-launcher/xcom2-launcher/Forms/UpdateAvailableDialog.cs
+++ b/xcom2-launcher/xcom2-launcher/Forms/UpdateAvailableDialog.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Diagnostics;
-using System.Globalization;
+﻿using System.Globalization;
 using System.Linq;
 using System.Windows.Forms;
 using HeyRed.MarkdownSharp;
@@ -19,7 +17,8 @@ namespace XCOM2Launcher.Forms
         public UpdateAvailableDialog(Release release, SemVersion currentVersion, SemVersion newVersion)
         {
             InitializeComponent();
-            
+
+            CancelButton = bClose;
             releaseNoteBrowser.Navigating += Tools.HandleNavigateWebBrowserControl;
 
             CurrentVersion = currentVersion.ToString();
@@ -47,11 +46,6 @@ namespace XCOM2Launcher.Forms
 
             filesize_value_label.Text = asset == null ? "No download available yet." : Helper.FileSizeFormatExtension.FormatAsFileSize(asset.size);
 
-        }
-
-        private void close_button_Click(object sender, System.EventArgs e)
-        {
-            Close();
         }
 
         private void show_button_Click(object sender, System.EventArgs e)

--- a/xcom2-launcher/xcom2-launcher/Forms/WelcomeDialog.Designer.cs
+++ b/xcom2-launcher/xcom2-launcher/Forms/WelcomeDialog.Designer.cs
@@ -23,231 +23,232 @@
 		/// the contents of this method with the code editor.
 		/// </summary>
 		private void InitializeComponent() {
-			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(WelcomeDialog));
-			this.label1 = new System.Windows.Forms.Label();
-			this.pictureBox1 = new System.Windows.Forms.PictureBox();
-			this.bContinue = new System.Windows.Forms.Button();
-			this.label2 = new System.Windows.Forms.Label();
-			this.label3 = new System.Windows.Forms.Label();
-			this.rSentryEnabled = new System.Windows.Forms.RadioButton();
-			this.rSentryDisabled = new System.Windows.Forms.RadioButton();
-			this.label5 = new System.Windows.Forms.Label();
-			this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-			this.rGameXCom2 = new System.Windows.Forms.RadioButton();
-			this.rGameChimera = new System.Windows.Forms.RadioButton();
-			this.panel1 = new System.Windows.Forms.Panel();
-			this.panel2 = new System.Windows.Forms.Panel();
-			this.label4 = new System.Windows.Forms.Label();
-			((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
-			this.tableLayoutPanel1.SuspendLayout();
-			this.panel1.SuspendLayout();
-			this.panel2.SuspendLayout();
-			this.SuspendLayout();
-			// 
-			// label1
-			// 
-			this.label1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(WelcomeDialog));
+            this.label1 = new System.Windows.Forms.Label();
+            this.pictureBox1 = new System.Windows.Forms.PictureBox();
+            this.bContinue = new System.Windows.Forms.Button();
+            this.label2 = new System.Windows.Forms.Label();
+            this.label3 = new System.Windows.Forms.Label();
+            this.rSentryEnabled = new System.Windows.Forms.RadioButton();
+            this.rSentryDisabled = new System.Windows.Forms.RadioButton();
+            this.label5 = new System.Windows.Forms.Label();
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.rGameXCom2 = new System.Windows.Forms.RadioButton();
+            this.rGameChimera = new System.Windows.Forms.RadioButton();
+            this.panel1 = new System.Windows.Forms.Panel();
+            this.panel2 = new System.Windows.Forms.Panel();
+            this.label4 = new System.Windows.Forms.Label();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
+            this.tableLayoutPanel1.SuspendLayout();
+            this.panel1.SuspendLayout();
+            this.panel2.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // label1
+            // 
+            this.label1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.label1.Location = new System.Drawing.Point(31, 5);
-			this.label1.Name = "label1";
-			this.label1.Size = new System.Drawing.Size(481, 20);
-			this.label1.TabIndex = 0;
-			this.label1.Text = "Please help us to improve AML, by enabling anonymous error reporting!";
-			this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// pictureBox1
-			// 
-			this.pictureBox1.Image = ((System.Drawing.Image)(resources.GetObject("pictureBox1.Image")));
-			this.pictureBox1.Location = new System.Drawing.Point(162, 68);
-			this.pictureBox1.Name = "pictureBox1";
-			this.pictureBox1.Size = new System.Drawing.Size(245, 110);
-			this.pictureBox1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
-			this.pictureBox1.TabIndex = 1;
-			this.pictureBox1.TabStop = false;
-			// 
-			// bContinue
-			// 
-			this.bContinue.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
-			this.bContinue.AutoSize = true;
-			this.bContinue.Enabled = false;
-			this.bContinue.Image = ((System.Drawing.Image)(resources.GetObject("bContinue.Image")));
-			this.bContinue.Location = new System.Drawing.Point(218, 453);
-			this.bContinue.Name = "bContinue";
-			this.bContinue.Size = new System.Drawing.Size(132, 33);
-			this.bContinue.TabIndex = 2;
-			this.bContinue.UseVisualStyleBackColor = true;
-			this.bContinue.Click += new System.EventHandler(this.bContinue_Click);
-			// 
-			// label2
-			// 
-			this.label2.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label1.Location = new System.Drawing.Point(31, 5);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(481, 20);
+            this.label1.TabIndex = 0;
+            this.label1.Text = "Please help us to improve AML, by enabling anonymous error reporting!";
+            this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // pictureBox1
+            // 
+            this.pictureBox1.Image = ((System.Drawing.Image)(resources.GetObject("pictureBox1.Image")));
+            this.pictureBox1.Location = new System.Drawing.Point(162, 68);
+            this.pictureBox1.Name = "pictureBox1";
+            this.pictureBox1.Size = new System.Drawing.Size(245, 110);
+            this.pictureBox1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
+            this.pictureBox1.TabIndex = 1;
+            this.pictureBox1.TabStop = false;
+            // 
+            // bContinue
+            // 
+            this.bContinue.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
+            this.bContinue.AutoSize = true;
+            this.bContinue.Enabled = false;
+            this.bContinue.Image = ((System.Drawing.Image)(resources.GetObject("bContinue.Image")));
+            this.bContinue.Location = new System.Drawing.Point(218, 453);
+            this.bContinue.Name = "bContinue";
+            this.bContinue.Size = new System.Drawing.Size(132, 33);
+            this.bContinue.TabIndex = 2;
+            this.bContinue.UseVisualStyleBackColor = true;
+            this.bContinue.Click += new System.EventHandler(this.bContinue_Click);
+            // 
+            // label2
+            // 
+            this.label2.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.label2.Location = new System.Drawing.Point(16, 38);
-			this.label2.Name = "label2";
-			this.label2.Size = new System.Drawing.Size(541, 20);
-			this.label2.TabIndex = 3;
-			this.label2.Text = "You are seeing this dialog, because you are starting AML for the first time.";
-			this.label2.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// label3
-			// 
-			this.label3.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.label2.Location = new System.Drawing.Point(16, 38);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(541, 20);
+            this.label2.TabIndex = 3;
+            this.label2.Text = "You are seeing this dialog, because you are starting AML for the first time.";
+            this.label2.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // label3
+            // 
+            this.label3.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.label3.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.label3.Location = new System.Drawing.Point(16, 12);
-			this.label3.Name = "label3";
-			this.label3.Size = new System.Drawing.Size(541, 20);
-			this.label3.TabIndex = 4;
-			this.label3.Text = "Welcome to the Alternative Mod Launcher!";
-			this.label3.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// rSentryEnabled
-			// 
-			this.rSentryEnabled.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.rSentryEnabled.Appearance = System.Windows.Forms.Appearance.Button;
-			this.rSentryEnabled.Checked = true;
-			this.rSentryEnabled.FlatAppearance.CheckedBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(84)))), ((int)(((byte)(179)))), ((int)(((byte)(94)))));
-			this.rSentryEnabled.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-			this.rSentryEnabled.Font = new System.Drawing.Font("Arial", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.rSentryEnabled.Location = new System.Drawing.Point(297, 31);
-			this.rSentryEnabled.Name = "rSentryEnabled";
-			this.rSentryEnabled.Size = new System.Drawing.Size(104, 24);
-			this.rSentryEnabled.TabIndex = 6;
-			this.rSentryEnabled.TabStop = true;
-			this.rSentryEnabled.Text = "ENABLED";
-			this.rSentryEnabled.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			this.rSentryEnabled.UseVisualStyleBackColor = true;
-			// 
-			// rSentryDisabled
-			// 
-			this.rSentryDisabled.Appearance = System.Windows.Forms.Appearance.Button;
-			this.rSentryDisabled.FlatAppearance.CheckedBackColor = System.Drawing.Color.Red;
-			this.rSentryDisabled.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-			this.rSentryDisabled.Font = new System.Drawing.Font("Helvetica", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.rSentryDisabled.Location = new System.Drawing.Point(143, 31);
-			this.rSentryDisabled.Name = "rSentryDisabled";
-			this.rSentryDisabled.Size = new System.Drawing.Size(104, 24);
-			this.rSentryDisabled.TabIndex = 7;
-			this.rSentryDisabled.Text = "DISABLED";
-			this.rSentryDisabled.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			this.rSentryDisabled.UseVisualStyleBackColor = true;
-			// 
-			// label5
-			// 
-			this.label5.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.label3.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label3.Location = new System.Drawing.Point(16, 12);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(541, 20);
+            this.label3.TabIndex = 4;
+            this.label3.Text = "Welcome to the Alternative Mod Launcher!";
+            this.label3.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // rSentryEnabled
+            // 
+            this.rSentryEnabled.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.rSentryEnabled.Appearance = System.Windows.Forms.Appearance.Button;
+            this.rSentryEnabled.Checked = true;
+            this.rSentryEnabled.FlatAppearance.CheckedBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(84)))), ((int)(((byte)(179)))), ((int)(((byte)(94)))));
+            this.rSentryEnabled.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.rSentryEnabled.Font = new System.Drawing.Font("Arial", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.rSentryEnabled.Location = new System.Drawing.Point(297, 31);
+            this.rSentryEnabled.Name = "rSentryEnabled";
+            this.rSentryEnabled.Size = new System.Drawing.Size(104, 24);
+            this.rSentryEnabled.TabIndex = 6;
+            this.rSentryEnabled.TabStop = true;
+            this.rSentryEnabled.Text = "ENABLED";
+            this.rSentryEnabled.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.rSentryEnabled.UseVisualStyleBackColor = true;
+            // 
+            // rSentryDisabled
+            // 
+            this.rSentryDisabled.Appearance = System.Windows.Forms.Appearance.Button;
+            this.rSentryDisabled.FlatAppearance.CheckedBackColor = System.Drawing.Color.Red;
+            this.rSentryDisabled.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.rSentryDisabled.Font = new System.Drawing.Font("Helvetica", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.rSentryDisabled.Location = new System.Drawing.Point(143, 31);
+            this.rSentryDisabled.Name = "rSentryDisabled";
+            this.rSentryDisabled.Size = new System.Drawing.Size(104, 24);
+            this.rSentryDisabled.TabIndex = 7;
+            this.rSentryDisabled.Text = "DISABLED";
+            this.rSentryDisabled.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.rSentryDisabled.UseVisualStyleBackColor = true;
+            // 
+            // label5
+            // 
+            this.label5.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.label5.Location = new System.Drawing.Point(10, 57);
-			this.label5.Name = "label5";
-			this.label5.Size = new System.Drawing.Size(525, 21);
-			this.label5.TabIndex = 9;
-			this.label5.Text = "You can enable/disable this feature at any time from the Settings dialog.";
-			this.label5.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// tableLayoutPanel1
-			// 
-			this.tableLayoutPanel1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.label5.Location = new System.Drawing.Point(10, 57);
+            this.label5.Name = "label5";
+            this.label5.Size = new System.Drawing.Size(525, 21);
+            this.label5.TabIndex = 9;
+            this.label5.Text = "You can enable/disable this feature at any time from the Settings dialog.";
+            this.label5.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // tableLayoutPanel1
+            // 
+            this.tableLayoutPanel1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.tableLayoutPanel1.ColumnCount = 2;
-			this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
-			this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
-			this.tableLayoutPanel1.Controls.Add(this.rGameXCom2, 0, 0);
-			this.tableLayoutPanel1.Controls.Add(this.rGameChimera, 1, 0);
-			this.tableLayoutPanel1.Location = new System.Drawing.Point(97, 28);
-			this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-			this.tableLayoutPanel1.RowCount = 1;
-			this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
-			this.tableLayoutPanel1.Size = new System.Drawing.Size(351, 138);
-			this.tableLayoutPanel1.TabIndex = 13;
-			// 
-			// rGameXCom2
-			// 
-			this.rGameXCom2.Anchor = System.Windows.Forms.AnchorStyles.None;
-			this.rGameXCom2.Appearance = System.Windows.Forms.Appearance.Button;
-			this.rGameXCom2.FlatAppearance.CheckedBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(84)))), ((int)(((byte)(179)))), ((int)(((byte)(94)))));
-			this.rGameXCom2.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-			this.rGameXCom2.Image = ((System.Drawing.Image)(resources.GetObject("rGameXCom2.Image")));
-			this.rGameXCom2.Location = new System.Drawing.Point(22, 4);
-			this.rGameXCom2.Name = "rGameXCom2";
-			this.rGameXCom2.Size = new System.Drawing.Size(130, 130);
-			this.rGameXCom2.TabIndex = 9;
-			this.rGameXCom2.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			this.rGameXCom2.UseVisualStyleBackColor = true;
-			this.rGameXCom2.CheckedChanged += new System.EventHandler(this.GameSelectionChanged);
-			// 
-			// rGameChimera
-			// 
-			this.rGameChimera.Anchor = System.Windows.Forms.AnchorStyles.None;
-			this.rGameChimera.Appearance = System.Windows.Forms.Appearance.Button;
-			this.rGameChimera.FlatAppearance.CheckedBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(84)))), ((int)(((byte)(179)))), ((int)(((byte)(94)))));
-			this.rGameChimera.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-			this.rGameChimera.Image = ((System.Drawing.Image)(resources.GetObject("rGameChimera.Image")));
-			this.rGameChimera.Location = new System.Drawing.Point(198, 4);
-			this.rGameChimera.Name = "rGameChimera";
-			this.rGameChimera.Size = new System.Drawing.Size(130, 130);
-			this.rGameChimera.TabIndex = 8;
-			this.rGameChimera.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			this.rGameChimera.UseVisualStyleBackColor = true;
-			this.rGameChimera.CheckedChanged += new System.EventHandler(this.GameSelectionChanged);
-			// 
-			// panel1
-			// 
-			this.panel1.Controls.Add(this.label1);
-			this.panel1.Controls.Add(this.rSentryEnabled);
-			this.panel1.Controls.Add(this.label5);
-			this.panel1.Controls.Add(this.rSentryDisabled);
-			this.panel1.Location = new System.Drawing.Point(12, 361);
-			this.panel1.Name = "panel1";
-			this.panel1.Size = new System.Drawing.Size(545, 87);
-			this.panel1.TabIndex = 14;
-			// 
-			// panel2
-			// 
-			this.panel2.Controls.Add(this.label4);
-			this.panel2.Controls.Add(this.tableLayoutPanel1);
-			this.panel2.Location = new System.Drawing.Point(12, 184);
-			this.panel2.Name = "panel2";
-			this.panel2.Size = new System.Drawing.Size(545, 171);
-			this.panel2.TabIndex = 15;
-			// 
-			// label4
-			// 
-			this.label4.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.tableLayoutPanel1.ColumnCount = 2;
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.tableLayoutPanel1.Controls.Add(this.rGameXCom2, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.rGameChimera, 1, 0);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(97, 28);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            this.tableLayoutPanel1.RowCount = 1;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(351, 138);
+            this.tableLayoutPanel1.TabIndex = 13;
+            // 
+            // rGameXCom2
+            // 
+            this.rGameXCom2.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.rGameXCom2.Appearance = System.Windows.Forms.Appearance.Button;
+            this.rGameXCom2.FlatAppearance.CheckedBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(84)))), ((int)(((byte)(179)))), ((int)(((byte)(94)))));
+            this.rGameXCom2.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.rGameXCom2.Image = ((System.Drawing.Image)(resources.GetObject("rGameXCom2.Image")));
+            this.rGameXCom2.Location = new System.Drawing.Point(22, 4);
+            this.rGameXCom2.Name = "rGameXCom2";
+            this.rGameXCom2.Size = new System.Drawing.Size(130, 130);
+            this.rGameXCom2.TabIndex = 9;
+            this.rGameXCom2.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.rGameXCom2.UseVisualStyleBackColor = true;
+            this.rGameXCom2.CheckedChanged += new System.EventHandler(this.GameSelectionChanged);
+            // 
+            // rGameChimera
+            // 
+            this.rGameChimera.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.rGameChimera.Appearance = System.Windows.Forms.Appearance.Button;
+            this.rGameChimera.FlatAppearance.CheckedBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(84)))), ((int)(((byte)(179)))), ((int)(((byte)(94)))));
+            this.rGameChimera.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.rGameChimera.Image = ((System.Drawing.Image)(resources.GetObject("rGameChimera.Image")));
+            this.rGameChimera.Location = new System.Drawing.Point(198, 4);
+            this.rGameChimera.Name = "rGameChimera";
+            this.rGameChimera.Size = new System.Drawing.Size(130, 130);
+            this.rGameChimera.TabIndex = 8;
+            this.rGameChimera.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.rGameChimera.UseVisualStyleBackColor = true;
+            this.rGameChimera.CheckedChanged += new System.EventHandler(this.GameSelectionChanged);
+            // 
+            // panel1
+            // 
+            this.panel1.Controls.Add(this.label1);
+            this.panel1.Controls.Add(this.rSentryEnabled);
+            this.panel1.Controls.Add(this.label5);
+            this.panel1.Controls.Add(this.rSentryDisabled);
+            this.panel1.Location = new System.Drawing.Point(12, 361);
+            this.panel1.Name = "panel1";
+            this.panel1.Size = new System.Drawing.Size(545, 87);
+            this.panel1.TabIndex = 14;
+            // 
+            // panel2
+            // 
+            this.panel2.Controls.Add(this.label4);
+            this.panel2.Controls.Add(this.tableLayoutPanel1);
+            this.panel2.Location = new System.Drawing.Point(12, 184);
+            this.panel2.Name = "panel2";
+            this.panel2.Size = new System.Drawing.Size(545, 171);
+            this.panel2.TabIndex = 15;
+            // 
+            // label4
+            // 
+            this.label4.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.label4.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.label4.Location = new System.Drawing.Point(31, 5);
-			this.label4.Name = "label4";
-			this.label4.Size = new System.Drawing.Size(481, 20);
-			this.label4.TabIndex = 10;
-			this.label4.Text = "Select the game you want to use this copy of AML for!";
-			this.label4.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			// 
-			// WelcomeDialog
-			// 
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.ClientSize = new System.Drawing.Size(569, 490);
-			this.ControlBox = false;
-			this.Controls.Add(this.panel2);
-			this.Controls.Add(this.panel1);
-			this.Controls.Add(this.label3);
-			this.Controls.Add(this.label2);
-			this.Controls.Add(this.bContinue);
-			this.Controls.Add(this.pictureBox1);
-			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
-			this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-			this.MaximizeBox = false;
-			this.MinimizeBox = false;
-			this.Name = "WelcomeDialog";
-			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
-			this.Text = "Welcome to AML";
-			this.Load += new System.EventHandler(this.WelcomeDialog_Load);
-			((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
-			this.tableLayoutPanel1.ResumeLayout(false);
-			this.panel1.ResumeLayout(false);
-			this.panel2.ResumeLayout(false);
-			this.ResumeLayout(false);
-			this.PerformLayout();
+            this.label4.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label4.Location = new System.Drawing.Point(31, 5);
+            this.label4.Name = "label4";
+            this.label4.Size = new System.Drawing.Size(481, 20);
+            this.label4.TabIndex = 10;
+            this.label4.Text = "Select the game you want to use this copy of AML for!";
+            this.label4.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // WelcomeDialog
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(569, 490);
+            this.Controls.Add(this.panel2);
+            this.Controls.Add(this.panel1);
+            this.Controls.Add(this.label3);
+            this.Controls.Add(this.label2);
+            this.Controls.Add(this.bContinue);
+            this.Controls.Add(this.pictureBox1);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.KeyPreview = true;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "WelcomeDialog";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.Text = "Welcome to AML";
+            this.Load += new System.EventHandler(this.WelcomeDialog_Load);
+            this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.WelcomeDialog_KeyDown);
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.panel1.ResumeLayout(false);
+            this.panel2.ResumeLayout(false);
+            this.ResumeLayout(false);
+            this.PerformLayout();
 
 		}
 

--- a/xcom2-launcher/xcom2-launcher/Forms/WelcomeDialog.cs
+++ b/xcom2-launcher/xcom2-launcher/Forms/WelcomeDialog.cs
@@ -1,11 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 using XCOM2Launcher.XCOM;
 
@@ -24,6 +17,7 @@ namespace XCOM2Launcher.Forms
 
         private void bContinue_Click(object sender, EventArgs e)
         {
+            DialogResult = DialogResult.OK;
             Close();
         }
 
@@ -35,6 +29,12 @@ namespace XCOM2Launcher.Forms
         {
             bContinue.Enabled = true;
             Game = rGameChimera.Checked ? GameId.ChimeraSquad : GameId.X2;
+        }
+
+        private void WelcomeDialog_KeyDown(object sender, KeyEventArgs e)
+        {
+            DialogResult = DialogResult.Cancel;
+            Close();
         }
     }
 }

--- a/xcom2-launcher/xcom2-launcher/Forms/WelcomeDialog.resx
+++ b/xcom2-launcher/xcom2-launcher/Forms/WelcomeDialog.resx
@@ -127,7 +127,7 @@
         41jCQ8JdScuW/ECiyEnF64qt7Kr5c0/1wuYle2Za6TI7iTBBlCk0DFZZJkuePlltUVxish+u4O/w/VPi
         MsS1jCmOMVaw0H0/6g9+d+umBgeKSc1hqH3yvLduqNuCr4LnfR563tcRVD/ChV3yrxzA8LvohZLWtQ+t
         G3B2WdKMbTjfhPaHnO7ovlQtM5BKweuJfNMstF1D43yxt599ju8gLl1NXsHuHvSkJXuhwrvry3v784zf
-        H+FvzGVyy3DDPTsAAAAJcEhZcwAALiMAAC4jAXilP3YAAAAHdElNRQfjCQsUGiFhfsfVAAD+IUlEQVR4
+        H+FvzGVyy3DDPTsAAAAJcEhZcwAALiIAAC4iAari3ZIAAAAHdElNRQfjCQsUGiFhfsfVAAD+IUlEQVR4
         XuydBVwVWf//hwZFGgQUQUC6UxoEaZQQC7G7u3XtWrt7jbVb1+5usUjpTnVLQXT//8937h0Y7461u8/z
         7O5PX6/Pa67DvTPnnDnn+z6fc2bOMP/v//2/r/qXC/+k/iJJ/0WS+aqvkpBQPfkjEqq3f0hCbemrPizB
         nV/175FkA/mDEmq0XyqhAPJHJfuZEvrtV/1x/TfLWKgOfamE6vIXSahNfZWwBHd+1d9XkpX9T0qoAX6J
@@ -2255,7 +2255,7 @@
   <data name="bContinue.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAAH4AAAAbCAIAAAA1eKw2AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wwAADsMBx2+oZAAAGRZJREFUaEOtWvd3G8e1BkiCIil2sIhUoSWxd1GUbVXKKhQL+u5ie0GlimMnLjkv
+        wgAADsIBFShKgAAAGRZJREFUaEOtWvd3G8e1BkiCIil2sIhUoSWxd1GUbVXKKhQL+u5ie0GlimMnLjkv
         L05zbMeJbbnE3Y6tLpIACaLT7697350FKUp23i9559yzZ3Ywe2fmu98ts1hHu/uwo6HG0eh0NDgcdTtS
         v6e9K/scVXvH2LJ35D66Ovc7HXUQh7Ox2rG/yoHbeluqHHVVjn241jjqXY66atZDIysCVQ1VjgYnPYXx
         0MYUktiNn/fQ4zsa8IjdsGXv4Gc67f7dKzXY2ira9gobg4XVO5y2YF/sKbuBnooG9Nid7FpV76hiPWxV


### PR DESCRIPTION
Fixes #332
- All dialogs can now be closed by pressing the escape key.
- The initial WelcomeDialog can now be properly "canceled" as well, effectively closing AML. Until now, it was possible to skip the dialog by pressing ALT+F4 and AML continued with default values.
- Added "Close" button to some dialogs for consistency.